### PR TITLE
Add Socket.IO chat backend and client scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 ws-server/node_modules/
 chat-history.json
+node_modules/

--- a/app.py
+++ b/app.py
@@ -1,0 +1,122 @@
+import time
+import sqlite3
+from flask import Flask, request
+from flask_socketio import SocketIO, emit
+from flask_login import current_user
+
+from db import DB_PATH
+
+app = Flask(__name__)
+socketio = SocketIO(app)
+active_users = {}
+sid_to_user = {}
+
+
+def get_active_users():
+    now = time.time()
+    return [u for u, t in active_users.items() if now - t < 30]
+
+
+def safe_emit(event, data=None, to=None):
+    socketio.emit(event, data, to=to)
+
+
+@socketio.on('connect')
+def chat_connect():
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT user, message, timestamp FROM chat_messages
+            WHERE timestamp >= datetime('now', '-1 day')
+            ORDER BY timestamp
+            """
+        )
+        rows = c.fetchall()
+        history = [{"user": r[0], "message": r[1], "timestamp": r[2]} for r in rows]
+    safe_emit('chat_history', history, to=request.sid)
+    safe_emit(
+        'active_user_update',
+        {'users': get_active_users(), 'count': len(get_active_users())},
+        to=request.sid,
+    )
+
+
+@socketio.on('get_chat_history')
+def get_chat_history():
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT user, message, timestamp FROM chat_messages
+            WHERE timestamp >= datetime('now', '-1 day')
+            ORDER BY timestamp
+            """
+        )
+        rows = c.fetchall()
+        history = [{"user": r[0], "message": r[1], "timestamp": r[2]} for r in rows]
+    emit('chat_history', history)
+
+
+@socketio.on('chat_message')
+def handle_chat_message(data):
+    msg = (data.get('message') or '').strip()
+    if not msg:
+        return
+    if not current_user.is_authenticated:
+        emit('chat_error', 'Login required to send messages.')
+        return
+    username = current_user.username
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute('INSERT INTO chat_messages (user, message) VALUES (?, ?)', (username, msg))
+        conn.commit()
+    safe_emit('chat_message', {'user': username, 'message': msg})
+
+
+@socketio.on('search_chat')
+def search_chat(data):
+    query = (data.get('query') or '').strip()
+    if not query:
+        emit('chat_search_results', [])
+        return
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        c.execute(
+            """
+            SELECT user, message, timestamp FROM chat_messages
+            WHERE timestamp >= datetime('now', '-1 day') AND (message LIKE ? OR user LIKE ?)
+            ORDER BY timestamp
+            """,
+            (f'%{query}%', f'%{query}%'),
+        )
+        rows = c.fetchall()
+        results = [{"user": r[0], "message": r[1], "timestamp": r[2]} for r in rows]
+    emit('chat_search_results', results)
+
+
+@socketio.on('user_ping')
+def handle_user_ping():
+    if current_user.is_authenticated:
+        active_users[current_user.username] = time.time()
+        sid_to_user[request.sid] = current_user.username
+        safe_emit('active_user_update', {
+            'users': get_active_users(),
+            'count': len(get_active_users())
+        })
+
+
+@socketio.event
+def disconnect():
+    sid = request.sid
+    print(f"Client {sid} disconnected")
+    user = sid_to_user.pop(sid, None)
+    if user and user in active_users:
+        active_users.pop(user, None)
+        safe_emit('active_user_update', {
+            'users': get_active_users(),
+            'count': len(get_active_users())
+        })
+
+
+if __name__ == '__main__':
+    socketio.run(app)

--- a/db.py
+++ b/db.py
@@ -1,0 +1,23 @@
+import os
+import sqlite3
+
+DB_PATH = os.environ.get("DB_PATH", "app.db")
+
+def init_db():
+    with sqlite3.connect(DB_PATH) as conn:
+        c = conn.cursor()
+        # chat log
+        c.execute(
+            """
+            CREATE TABLE IF NOT EXISTS chat_messages (
+              id        INTEGER PRIMARY KEY AUTOINCREMENT,
+              user      TEXT,
+              message   TEXT,
+              timestamp DATETIME DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        conn.commit()
+
+if __name__ == "__main__":
+    init_db()

--- a/static/chat.js
+++ b/static/chat.js
@@ -1,0 +1,113 @@
+(function(){
+  let chatSocket = null;
+  function createBox(){
+    const ctx = window.APP_CONTEXT || {};
+    const box = document.createElement('div');
+    box.id = 'chat-box';
+      Object.assign(box.style, {
+        position: 'fixed',
+        top: '0',
+        bottom: '0',
+        left: '0',
+        width: '50%',
+        background: '#1a1a1a',
+        color: '#ffd700',
+        borderRight: '2px solid #ffd700',
+        padding: '10px',
+        fontSize: '14px',
+        zIndex: 9999,
+        display: 'flex',
+        flexDirection: 'column',
+        boxSizing: 'border-box'
+      });
+      if(window.innerWidth < 600){
+        box.style.width = '100%';
+      }
+      box.innerHTML =
+      '<div id="chat-users" style="margin-bottom:4px;font-weight:bold;"></div>' +
+      '<div style="margin-bottom:4px;">' +
+      '<input id="chat-search" placeholder="Search..." style="width:100%;padding:4px;background:#222;border:1px solid #555;color:#ffd700;" />' +
+      '</div>' +
+      '<div id="chat-feed" style="overflow-y:auto;flex:1;margin-bottom:4px;background:#111;padding:4px;"></div>' +
+      '<form id="chat-form" style="display:flex;gap:4px;">' +
+      '<input id="chat-input" style="flex:1;padding:4px;background:#222;border:1px solid #555;color:#ffd700;" />' +
+      '<button style="padding:4px 8px;background:#b30000;color:#ffd700;border:1px solid #ffd700;">Send</button>' +
+      '</form>';
+    document.body.appendChild(box);
+
+    const usersBox = box.querySelector('#chat-users');
+    const feed = box.querySelector('#chat-feed');
+    const form = box.querySelector('#chat-form');
+    const input = box.querySelector('#chat-input');
+    const search = box.querySelector('#chat-search');
+    const sendAllowed = !!ctx.username;
+    const socket = io();
+    chatSocket = socket;
+    socket.on('connect', () => {
+      socket.emit('get_chat_history');
+    });
+    function appendMsg(data){
+      const msg = document.createElement('div');
+      msg.textContent = `${data.user}: ${data.message}`;
+      msg.style.color = '#00a0ff';
+      msg.style.textShadow = '0 0 4px gold';
+      feed.appendChild(msg);
+      feed.scrollTop = feed.scrollHeight;
+    }
+    function renderMessages(list){
+      feed.innerHTML = '';
+      list.forEach(appendMsg);
+    }
+    socket.on('chat_history', renderMessages);
+    socket.on('chat_search_results', renderMessages);
+    socket.on('chat_message', appendMsg);
+    socket.on('chat_error', msg => {
+      alert(msg);
+    });
+    socket.on('active_user_update', data => {
+      usersBox.textContent = `Active users (${data.count}): ${data.users.join(', ')}`;
+    });
+    if(!sendAllowed){
+      input.disabled = true;
+      input.placeholder = 'Login required to chat';
+    }
+    let searchTimer = null;
+    search.addEventListener('input', () => {
+      clearTimeout(searchTimer);
+      searchTimer = setTimeout(() => {
+        const q = search.value.trim();
+        if(q){
+          socket.emit('search_chat', {query: q});
+        } else {
+          socket.emit('get_chat_history');
+        }
+      }, 300);
+    });
+    form.addEventListener('submit', e => {
+      e.preventDefault();
+      if(!sendAllowed){
+        alert('Login required to chat');
+        return;
+      }
+      const txt = input.value.trim();
+      if(txt){
+        socket.emit('chat_message', {message: txt});
+        input.value = '';
+      }
+    });
+    return box;
+  }
+
+  window.initChatBox = function(){
+    let box = document.getElementById('chat-box');
+    if(box){
+      const showing = box.style.display === 'none';
+      box.style.display = showing ? 'block' : 'none';
+      if(showing && chatSocket){
+        chatSocket.emit('get_chat_history');
+      }
+      return;
+    }
+    createBox();
+  };
+})();

--- a/static/session.js
+++ b/static/session.js
@@ -1,0 +1,43 @@
+(function(){
+  const CHAIN_KEY = 'mixer_current_chain';
+  const CURRENCY_KEY = 'mixer_current_currency';
+  const WALLET_KEY = 'mixer_current_wallet';
+  const USER_KEY   = 'mixer_username';
+  const PASS_KEY   = 'mixer_password';
+  const USER_DATA_KEY = 'session_user';
+  document.addEventListener('DOMContentLoaded', () => {
+    const context = window.APP_CONTEXT = {};
+    const saved = localStorage.getItem(USER_DATA_KEY);
+    if(saved){
+      try{ Object.assign(context, JSON.parse(saved)); } catch {}
+    }
+    if(context.username){
+      const chatBtn = createIconButton('chat-toggle-btn', '/static/chat.svg');
+      container.appendChild(chatBtn);
+      // Inject live chat for logged-in users
+      const sio = document.createElement('script');
+      // Load Socket.IO client from the official CDN
+      sio.src = 'https://cdn.socket.io/4.7.5/socket.io.min.js';
+      document.body.appendChild(sio);
+      const script = document.createElement('script');
+      script.src = '/static/chat.js';
+      document.body.appendChild(script);
+      chatBtn.addEventListener('click', () => {
+        if(window.initChatBox){
+          window.initChatBox();
+        }
+      });
+      // keep socket connection alive for active user tracking
+      sio.onload = () => {
+        const socket = io();
+        socket.on('connect', () => {
+          socket.emit('user_ping');
+          setInterval(() => socket.emit('user_ping'), 10000);
+        });
+      };
+    } else {
+      const chatBtn = document.getElementById('chat-toggle-btn');
+      if(chatBtn) chatBtn.style.display = 'none';
+    }
+  });
+})();


### PR DESCRIPTION
## Summary
- add SQLite setup and Socket.IO event handlers for chat messages and active user tracking
- implement client-side chat box and session bootstrap scripts
- ignore repository `node_modules` in git

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab2041683883339afccd146cf816e6