### PR TITLE
feat: customize theme colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,26 +8,26 @@
   <meta name="color-scheme" content="dark light" />
   <style>
       :root {
-        --bg: #0c0f14;
-        --panel: #121722;
-        --muted: #8b97a8;
-        --fg: #e9eef7;
-        --accent: #c62828;
-        --accent-2: #ffd700;
+        --bg: #001a33;
+        --panel: #00264d;
+        --muted: #a0a0a0;
+        --fg: #c0c0c0;
+        --accent: #c0c0c0;
+        --accent-2: #e0e0e0;
         --danger: #ff5d6e;
-        --shadow: 0 6px 24px rgba(0,0,0,.25);
+        --shadow: 0 0 10px rgba(192,192,192,.5);
         --radius: 16px;
-        --lining: rgba(255,255,255,.06);
+        --lining: #c0c0c0;
       }
       :root[data-theme='light']{
-        --bg:#e0f2ff;
-        --panel:#ffffff;
-        --fg:#0d1726;
-        --muted:#5a6a85;
-        --accent:#1e88e5;
-        --accent-2:#c0c0c0;
-        --shadow: 0 6px 24px rgba(0,0,0,.08);
-        --lining:#c0c0c0;
+        --bg:#ff0000;
+        --panel:#ffe5e5;
+        --fg:#ffd700;
+        --muted:#c0a000;
+        --accent:#ff0000;
+        --accent-2:#ffd700;
+        --shadow: 0 0 10px rgba(255,215,0,.5);
+        --lining:#ffd700;
       }
     * { box-sizing: border-box; }
     html, body { height: 100%; }


### PR DESCRIPTION
## Summary
- implement dark mode with rich blue background and silver accents
- set regular theme to red and gold colors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab5087ad5c8333a76958fef05b65c9