### PR TITLE
feat: swap light theme pink background for dark grey

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,11 +20,11 @@
         --lining: #c0c0c0;
       }
       :root[data-theme='light']{
-        --bg:#ff0000;
-        --panel:#ffe5e5;
+        --bg:#1a1a1a;
+        --panel:#2a2a2a;
         --fg:#ffd700;
         --muted:#c0a000;
-        --accent:#ff0000;
+        --accent:#ffd700;
         --accent-2:#ffd700;
         --shadow: 0 0 10px rgba(255,215,0,.5);
         --lining:#ffd700;


### PR DESCRIPTION
## Summary
- replace pink-based light theme background with dark grey to pair with yellow accents

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab52a8fdcc8333aa5911c361c42a44