### PR TITLE
Expand accepted media types

### DIFF
--- a/index.html
+++ b/index.html
@@ -186,8 +186,8 @@
         <label class="input" for="text">
           <input id="text" name="text" placeholder="Type a message… (try /me waves or /clear)" />
         </label>
-        <input id="file" type="file" accept="image/*" hidden />
-        <button class="send" id="attach" type="button" title="Attach image" aria-label="Attach image">📎</button>
+        <input id="file" type="file" accept="image/png,image/jpeg,image/gif,image/webp,video/*,audio/*,.gltf,.glb" hidden />
+        <button class="send" id="attach" type="button" title="Attach file" aria-label="Attach file">📎</button>
         <button class="send" id="send" type="submit">Send</button>
       </form>
     </main>


### PR DESCRIPTION
## Summary
- Allow attaching video, audio, and glTF files in addition to images
- Update attach button labeling for broader file support

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab653592488333992274a3df12e90e