### PR TITLE
Add file-type backup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,10 @@ The WebSocket server stores the last 200 messages in `chat-history.json` at the
 repository root and automatically sends this history to new connections. It
 also broadcasts the number of currently connected users so the client can
 display a live online count.
+
+### File-type backups
+
+Run `python backup.py` to copy repository files into the `backups/` directory.
+The script uses the same backup process for every file type, storing each
+extension in its own subdirectory and preserving metadata so all files retain
+their information.

--- a/backup.py
+++ b/backup.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import os
+import shutil
+
+BACKUP_ROOT = 'backups'
+EXCLUDE_DIRS = {'.git', 'node_modules', BACKUP_ROOT}
+
+def backup():
+    for root, dirs, files in os.walk('.', topdown=True):
+        dirs[:] = [d for d in dirs if d not in EXCLUDE_DIRS and not d.startswith('.')]
+        for filename in files:
+            src_path = os.path.join(root, filename)
+            ext = os.path.splitext(filename)[1].lstrip('.')
+            if not ext:
+                ext = 'no_ext'
+            rel_dir = os.path.relpath(root, '.')
+            if rel_dir == '.':
+                rel_dir = ''
+            dest_dir = os.path.join(BACKUP_ROOT, ext, rel_dir)
+            os.makedirs(dest_dir, exist_ok=True)
+            shutil.copy2(src_path, os.path.join(dest_dir, filename))
+
+if __name__ == '__main__':
+    backup()


### PR DESCRIPTION
## Summary
- add backup script that stores files per extension under backups directory
- document backup usage in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ab6b18b9f883338edff22e8c84b326