### PR TITLE
Add video file handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 ws-server/node_modules/
 chat-history.json
 node_modules/
+__pycache__/
+app.db

--- a/app.py
+++ b/app.py
@@ -4,7 +4,10 @@ from flask import Flask, request
 from flask_socketio import SocketIO, emit
 from flask_login import current_user
 
-from db import DB_PATH
+from db import DB_PATH, init_db
+
+# ensure database schema is up to date
+init_db()
 
 app = Flask(__name__)
 socketio = SocketIO(app)
@@ -27,7 +30,7 @@ def chat_connect():
         c = conn.cursor()
         c.execute(
             """
-            SELECT user, message, image, file, file_name, file_type, timestamp FROM chat_messages
+            SELECT user, message, image, video, file, file_name, file_type, timestamp FROM chat_messages
             WHERE timestamp >= datetime('now', '-1 day')
             ORDER BY timestamp
             """
@@ -38,10 +41,11 @@ def chat_connect():
                 "user": r[0],
                 "message": r[1],
                 "image": r[2],
-                "file": r[3],
-                "file_name": r[4],
-                "file_type": r[5],
-                "timestamp": r[6],
+                "video": r[3],
+                "file": r[4],
+                "file_name": r[5],
+                "file_type": r[6],
+                "timestamp": r[7],
             }
             for r in rows
         ]
@@ -59,7 +63,7 @@ def get_chat_history():
         c = conn.cursor()
         c.execute(
             """
-            SELECT user, message, image, file, file_name, file_type, timestamp FROM chat_messages
+            SELECT user, message, image, video, file, file_name, file_type, timestamp FROM chat_messages
             WHERE timestamp >= datetime('now', '-1 day')
             ORDER BY timestamp
             """
@@ -70,10 +74,11 @@ def get_chat_history():
                 "user": r[0],
                 "message": r[1],
                 "image": r[2],
-                "file": r[3],
-                "file_name": r[4],
-                "file_type": r[5],
-                "timestamp": r[6],
+                "video": r[3],
+                "file": r[4],
+                "file_name": r[5],
+                "file_type": r[6],
+                "timestamp": r[7],
             }
             for r in rows
         ]
@@ -84,10 +89,11 @@ def get_chat_history():
 def handle_chat_message(data):
     msg = (data.get('message') or '').strip()
     img = data.get('image')
+    vid = data.get('video')
     file = data.get('file')
     file_name = data.get('file_name') or data.get('fileName')
     file_type = data.get('file_type') or data.get('fileType')
-    if not msg and not img and not file:
+    if not msg and not img and not vid and not file:
         return
     if not current_user.is_authenticated:
         emit('chat_error', 'Login required to send messages.')
@@ -95,8 +101,8 @@ def handle_chat_message(data):
     username = current_user.username
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(
-            'INSERT INTO chat_messages (user, message, image, file, file_name, file_type) VALUES (?, ?, ?, ?, ?, ?)',
-            (username, msg, img, file, file_name, file_type),
+            'INSERT INTO chat_messages (user, message, image, video, file, file_name, file_type) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            (username, msg, img, vid, file, file_name, file_type),
         )
         conn.commit()
     safe_emit(
@@ -105,6 +111,7 @@ def handle_chat_message(data):
             'user': username,
             'message': msg,
             'image': img,
+            'video': vid,
             'file': file,
             'file_name': file_name,
             'file_type': file_type,
@@ -122,7 +129,7 @@ def search_chat(data):
         c = conn.cursor()
         c.execute(
             """
-            SELECT user, message, image, file, file_name, file_type, timestamp FROM chat_messages
+            SELECT user, message, image, video, file, file_name, file_type, timestamp FROM chat_messages
             WHERE timestamp >= datetime('now', '-1 day') AND (message LIKE ? OR user LIKE ?)
             ORDER BY timestamp
             """,
@@ -134,10 +141,11 @@ def search_chat(data):
                 "user": r[0],
                 "message": r[1],
                 "image": r[2],
-                "file": r[3],
-                "file_name": r[4],
-                "file_type": r[5],
-                "timestamp": r[6],
+                "video": r[3],
+                "file": r[4],
+                "file_name": r[5],
+                "file_type": r[6],
+                "timestamp": r[7],
             }
             for r in rows
         ]

--- a/db.py
+++ b/db.py
@@ -14,6 +14,7 @@ def init_db():
               user      TEXT,
               message   TEXT,
               image     TEXT,
+              video     TEXT,
               file      TEXT,
               file_name TEXT,
               file_type TEXT,
@@ -21,6 +22,11 @@ def init_db():
             )
             """
         )
+        # ensure new columns exist for older databases
+        c.execute("PRAGMA table_info(chat_messages)")
+        cols = [row[1] for row in c.fetchall()]
+        if "video" not in cols:
+            c.execute("ALTER TABLE chat_messages ADD COLUMN video TEXT")
         conn.commit()
 
 if __name__ == "__main__":

--- a/index.html
+++ b/index.html
@@ -511,6 +511,9 @@
         if (file.type.startsWith('image/')) {
           msg.image = dataUrl;
           msg.name = file.name;
+        } else if (file.type.startsWith('video/')) {
+          msg.video = dataUrl;
+          msg.name = file.name;
         }
         postMessage(msg);
       };
@@ -518,13 +521,14 @@
       fileInput.value = '';
     });
 
-    function postMessage({ text='', image, file, fileName, fileType, name, isAction=false }){
+    function postMessage({ text='', image, video, file, fileName, fileType, name, isAction=false }){
       const msg = {
         id: Date.now().toString(36) + Math.random().toString(36).slice(2,7),
         type: 'chat',
         user: store.user,
         text: text,
         image: image,
+        video: video,
         file: file,
         fileName: fileName || name,
         fileType: fileType,
@@ -667,7 +671,7 @@
 
       bubble.appendChild(meta);
       bubble.appendChild(text);
-      const fileData = m.file || m.image;
+      const fileData = m.file || m.video || m.image;
       if(fileData){
         const mime = m.fileType || ((fileData.match(/^data:(.*?);/) || [])[1] || '');
         const filename = m.fileName || m.name || '';

--- a/package-lock.json
+++ b/package-lock.json
@@ -198,6 +198,27 @@
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/mimic-response": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
@@ -489,6 +510,7 @@
       "name": "chaines-chat-ws",
       "dependencies": {
         "better-sqlite3": "^9.0.0",
+        "mime-types": "^2.1.35",
         "ws": "^8.18.0"
       }
     }

--- a/ws-server/package.json
+++ b/ws-server/package.json
@@ -3,5 +3,5 @@
   "private": true,
   "type": "module",
   "scripts": { "start": "node server.js", "build": "echo no-build" },
-  "dependencies": { "ws": "^8.18.0", "better-sqlite3": "^9.0.0" }
+  "dependencies": { "ws": "^8.18.0", "better-sqlite3": "^9.0.0", "mime-types": "^2.1.35" }
 }


### PR DESCRIPTION
## Summary
- Support video uploads and rendering in the chat client
- Store video data and MIME info on the server via new column
- Auto-migrate existing databases to include the video column

## Testing
- `python -m py_compile app.py db.py`
- `npm test`
- `python db.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab76fc566c8333b67eb564cad5aab8