### PR TITLE
Add live broadcast posts to chat feed

### DIFF
--- a/app.py
+++ b/app.py
@@ -30,7 +30,7 @@ def chat_connect():
         c = conn.cursor()
         c.execute(
             """
-            SELECT user, message, image, video, file, file_name, file_type, timestamp FROM chat_messages
+            SELECT user, message, image, video, broadcast, file, file_name, file_type, timestamp FROM chat_messages
             WHERE timestamp >= datetime('now', '-1 day')
             ORDER BY timestamp
             """
@@ -42,10 +42,11 @@ def chat_connect():
                 "message": r[1],
                 "image": r[2],
                 "video": r[3],
-                "file": r[4],
-                "file_name": r[5],
-                "file_type": r[6],
-                "timestamp": r[7],
+                "broadcast": r[4],
+                "file": r[5],
+                "file_name": r[6],
+                "file_type": r[7],
+                "timestamp": r[8],
             }
             for r in rows
         ]
@@ -63,7 +64,7 @@ def get_chat_history():
         c = conn.cursor()
         c.execute(
             """
-            SELECT user, message, image, video, file, file_name, file_type, timestamp FROM chat_messages
+            SELECT user, message, image, video, broadcast, file, file_name, file_type, timestamp FROM chat_messages
             WHERE timestamp >= datetime('now', '-1 day')
             ORDER BY timestamp
             """
@@ -75,10 +76,11 @@ def get_chat_history():
                 "message": r[1],
                 "image": r[2],
                 "video": r[3],
-                "file": r[4],
-                "file_name": r[5],
-                "file_type": r[6],
-                "timestamp": r[7],
+                "broadcast": r[4],
+                "file": r[5],
+                "file_name": r[6],
+                "file_type": r[7],
+                "timestamp": r[8],
             }
             for r in rows
         ]
@@ -90,10 +92,11 @@ def handle_chat_message(data):
     msg = (data.get('message') or '').strip()
     img = data.get('image')
     vid = data.get('video')
+    broadcast = data.get('broadcast')
     file = data.get('file')
     file_name = data.get('file_name') or data.get('fileName')
     file_type = data.get('file_type') or data.get('fileType')
-    if not msg and not img and not vid and not file:
+    if not msg and not img and not vid and not file and not broadcast:
         return
     if not current_user.is_authenticated:
         emit('chat_error', 'Login required to send messages.')
@@ -101,8 +104,8 @@ def handle_chat_message(data):
     username = current_user.username
     with sqlite3.connect(DB_PATH) as conn:
         conn.execute(
-            'INSERT INTO chat_messages (user, message, image, video, file, file_name, file_type) VALUES (?, ?, ?, ?, ?, ?, ?)',
-            (username, msg, img, vid, file, file_name, file_type),
+            'INSERT INTO chat_messages (user, message, image, video, broadcast, file, file_name, file_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?)',
+            (username, msg, img, vid, broadcast, file, file_name, file_type),
         )
         conn.commit()
     safe_emit(
@@ -112,6 +115,7 @@ def handle_chat_message(data):
             'message': msg,
             'image': img,
             'video': vid,
+            'broadcast': broadcast,
             'file': file,
             'file_name': file_name,
             'file_type': file_type,
@@ -129,7 +133,7 @@ def search_chat(data):
         c = conn.cursor()
         c.execute(
             """
-            SELECT user, message, image, video, file, file_name, file_type, timestamp FROM chat_messages
+            SELECT user, message, image, video, broadcast, file, file_name, file_type, timestamp FROM chat_messages
             WHERE timestamp >= datetime('now', '-1 day') AND (message LIKE ? OR user LIKE ?)
             ORDER BY timestamp
             """,
@@ -142,10 +146,11 @@ def search_chat(data):
                 "message": r[1],
                 "image": r[2],
                 "video": r[3],
-                "file": r[4],
-                "file_name": r[5],
-                "file_type": r[6],
-                "timestamp": r[7],
+                "broadcast": r[4],
+                "file": r[5],
+                "file_name": r[6],
+                "file_type": r[7],
+                "timestamp": r[8],
             }
             for r in rows
         ]

--- a/db.py
+++ b/db.py
@@ -15,6 +15,7 @@ def init_db():
               message   TEXT,
               image     TEXT,
               video     TEXT,
+              broadcast TEXT,
               file      TEXT,
               file_name TEXT,
               file_type TEXT,
@@ -27,6 +28,8 @@ def init_db():
         cols = [row[1] for row in c.fetchall()]
         if "video" not in cols:
             c.execute("ALTER TABLE chat_messages ADD COLUMN video TEXT")
+        if "broadcast" not in cols:
+            c.execute("ALTER TABLE chat_messages ADD COLUMN broadcast TEXT")
         conn.commit()
 
 if __name__ == "__main__":

--- a/index.html
+++ b/index.html
@@ -521,7 +521,7 @@
       fileInput.value = '';
     });
 
-    function postMessage({ text='', image, video, file, fileName, fileType, name, isAction=false }){
+    function postMessage({ text='', image, video, file, fileName, fileType, name, broadcast, isAction=false }){
       const msg = {
         id: Date.now().toString(36) + Math.random().toString(36).slice(2,7),
         type: 'chat',
@@ -529,6 +529,7 @@
         text: text,
         image: image,
         video: video,
+        broadcast: broadcast,
         file: file,
         fileName: fileName || name,
         fileType: fileType,
@@ -562,6 +563,7 @@
         vid.playsInline = true;
         videoContainer.appendChild(vid);
         sendSignal({ type: 'broadcaster' });
+        postMessage({ text: '\uD83D\uDD34 Live broadcast', broadcast: true });
       }).catch(() => alert('Unable to access camera/microphone'));
     }
 
@@ -714,6 +716,14 @@
           link.download = filename || 'file';
           bubble.appendChild(link);
         }
+      }
+
+      if(m.broadcast){
+        const btn = document.createElement('button');
+        btn.className = 'live-btn';
+        btn.innerHTML = '<span class="live-dot"></span> Join Live';
+        btn.addEventListener('click', startWatching);
+        bubble.appendChild(btn);
       }
 
       if(mine){

--- a/ws-server/server.js
+++ b/ws-server/server.js
@@ -22,6 +22,7 @@ db.exec(`
     message TEXT,
     image TEXT,
     video TEXT,
+    broadcast TEXT,
     file TEXT,
     file_name TEXT,
     file_type TEXT,
@@ -36,11 +37,14 @@ const columns = db
 if (!columns.includes("video")) {
   db.exec("ALTER TABLE chat_messages ADD COLUMN video TEXT");
 }
+if (!columns.includes("broadcast")) {
+  db.exec("ALTER TABLE chat_messages ADD COLUMN broadcast TEXT");
+}
 
 function loadHistory(limit = 200) {
   const rows = db
     .prepare(
-      `SELECT id, user, message, image, video, file, file_name as fileName, file_type as fileType, strftime('%s', timestamp) * 1000 as ts FROM chat_messages ORDER BY id DESC LIMIT ?`
+      `SELECT id, user, message, image, video, broadcast, file, file_name as fileName, file_type as fileType, strftime('%s', timestamp) * 1000 as ts FROM chat_messages ORDER BY id DESC LIMIT ?`
     )
     .all(limit)
     .reverse();
@@ -161,13 +165,14 @@ wss.on("connection", (ws) => {
     const text = msg.text ?? msg.message ?? "";
     const info = db
       .prepare(
-        "INSERT INTO chat_messages (user, message, image, video, file, file_name, file_type) VALUES (?, ?, ?, ?, ?, ?, ?)"
+        "INSERT INTO chat_messages (user, message, image, video, broadcast, file, file_name, file_type) VALUES (?, ?, ?, ?, ?, ?, ?, ?)"
       )
       .run(
         msg.user || "",
         text,
         msg.image || null,
         msg.video || null,
+        msg.broadcast || null,
         msg.file || null,
         msg.fileName || null,
         msg.fileType || null


### PR DESCRIPTION
## Summary
- extend database schema with `broadcast` column for live feeds
- include broadcast data in Python and Node chat message handling
- allow client to post and display live broadcast entries with join button

## Testing
- `python -m py_compile app.py db.py`
- `node --check ws-server/server.js`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ab838759bc83339f4d76876fc1b37e