### PR TITLE
feat: allow ending live broadcast

### DIFF
--- a/index.html
+++ b/index.html
@@ -578,34 +578,28 @@
       }).catch(() => alert('Unable to access camera/microphone'));
     }
 
-    function endBroadcast(forced=false){
+    async function endBroadcast(forced=false){
       if(!broadcasting) return;
       broadcasting = false;
       broadcastBtn.textContent = '\uD83C\uDFA5 Live';
       broadcastBtn.title = 'Go live';
       const note = forced ? new Date().toLocaleString() :
         (prompt('Broadcast end comment?') || '').trim();
-      const hadRecorder = !!mediaRecorder;
+
+      let dataUrl = null;
       if(mediaRecorder){
-        mediaRecorder.onstop = () => {
-          const blob = new Blob(recordedChunks, { type: 'video/webm' });
-          const reader = new FileReader();
-          reader.onloadend = () => {
-            const dataUrl = reader.result;
-            postMessage({
-              text: `\u23F9 Broadcast ended${note ? ': '+note : ''}`,
-              video: dataUrl,
-              file: dataUrl,
-              fileName: `broadcast-${Date.now()}.webm`,
-              fileType: 'video/webm',
-              broadcast: true
-            });
-          };
-          reader.readAsDataURL(blob);
-        };
-        try { mediaRecorder.stop(); } catch {}
+        try {
+          dataUrl = await new Promise((resolve) => {
+            mediaRecorder.onstop = () => {
+              const blob = new Blob(recordedChunks, { type: 'video/webm' });
+              blobToDataURL(blob).then(resolve);
+            };
+            mediaRecorder.stop();
+          });
+        } catch {}
         mediaRecorder = null;
       }
+
       if(localStream){
         localStream.getTracks().forEach(t => t.stop());
         localStream = null;
@@ -617,9 +611,19 @@
       sendSignal({ type: 'end-broadcast' });
       videoContainer.innerHTML = '';
       videoContainer.setAttribute('hidden','');
-      if(!hadRecorder){
-        postMessage({ text: `\u23F9 Broadcast ended${note ? ': '+note : ''}`, broadcast: true });
+
+      const msg = {
+        text: `\u23F9 Broadcast ended${note ? ': '+note : ''}`,
+        broadcast: true
+      };
+      if(dataUrl){
+        Object.assign(msg, {
+          video: dataUrl,
+          fileType: 'video/webm',
+          fileName: `broadcast-${Date.now()}.webm`
+        });
       }
+      postMessage(msg);
     }
 
     function startWatching(){
@@ -832,6 +836,14 @@
       const safe = escapeHTML(s);
       const withLinks = linkify(safe);
       return isAction ? `<em>${withLinks}</em>` : withLinks;
+    }
+
+    function blobToDataURL(blob){
+      return new Promise(resolve => {
+        const reader = new FileReader();
+        reader.onloadend = () => resolve(reader.result);
+        reader.readAsDataURL(blob);
+      });
     }
 
     // Boot

--- a/index.html
+++ b/index.html
@@ -318,7 +318,8 @@
         connectWS();
       }
     });
-    broadcastBtn.addEventListener('click', startBroadcast);
+    broadcastBtn.addEventListener('click', () => broadcasting ? endBroadcast() : startBroadcast());
+    window.addEventListener('beforeunload', () => endBroadcast(true));
 
     // --- Connection setup (optional WebSocket + local BroadcastChannel fallback) ---
     let socket = null;
@@ -332,6 +333,8 @@
     let clientId = null;
     let hostId = null;
     let broadcasting = false;
+    let mediaRecorder = null;
+    let recordedChunks = [];
     function updateUsers(list){
       liveCount.textContent = list.length;
       usersEl.innerHTML = '';
@@ -554,7 +557,15 @@
       if(broadcasting) return;
       navigator.mediaDevices.getUserMedia({ video:true, audio:true }).then(stream => {
         localStream = stream;
+        recordedChunks = [];
+        try {
+          mediaRecorder = new MediaRecorder(stream);
+          mediaRecorder.ondataavailable = e => { if(e.data.size) recordedChunks.push(e.data); };
+          mediaRecorder.start();
+        } catch {}
         broadcasting = true;
+        broadcastBtn.textContent = '\u23F9 End';
+        broadcastBtn.title = 'End live broadcast';
         videoContainer.removeAttribute('hidden');
         const vid = document.createElement('video');
         vid.srcObject = stream;
@@ -565,6 +576,50 @@
         sendSignal({ type: 'broadcaster' });
         postMessage({ text: '\uD83D\uDD34 Live broadcast', broadcast: true });
       }).catch(() => alert('Unable to access camera/microphone'));
+    }
+
+    function endBroadcast(forced=false){
+      if(!broadcasting) return;
+      broadcasting = false;
+      broadcastBtn.textContent = '\uD83C\uDFA5 Live';
+      broadcastBtn.title = 'Go live';
+      const note = forced ? new Date().toLocaleString() :
+        (prompt('Broadcast end comment?') || '').trim();
+      const hadRecorder = !!mediaRecorder;
+      if(mediaRecorder){
+        mediaRecorder.onstop = () => {
+          const blob = new Blob(recordedChunks, { type: 'video/webm' });
+          const reader = new FileReader();
+          reader.onloadend = () => {
+            const dataUrl = reader.result;
+            postMessage({
+              text: `\u23F9 Broadcast ended${note ? ': '+note : ''}`,
+              video: dataUrl,
+              file: dataUrl,
+              fileName: `broadcast-${Date.now()}.webm`,
+              fileType: 'video/webm',
+              broadcast: true
+            });
+          };
+          reader.readAsDataURL(blob);
+        };
+        try { mediaRecorder.stop(); } catch {}
+        mediaRecorder = null;
+      }
+      if(localStream){
+        localStream.getTracks().forEach(t => t.stop());
+        localStream = null;
+      }
+      for(const id in peerConnections){
+        try{ peerConnections[id].close(); }catch{}
+        delete peerConnections[id];
+      }
+      sendSignal({ type: 'end-broadcast' });
+      videoContainer.innerHTML = '';
+      videoContainer.setAttribute('hidden','');
+      if(!hadRecorder){
+        postMessage({ text: `\u23F9 Broadcast ended${note ? ': '+note : ''}`, broadcast: true });
+      }
     }
 
     function startWatching(){

--- a/ws-server/server.js
+++ b/ws-server/server.js
@@ -136,6 +136,17 @@ wss.on("connection", (ws) => {
           }
         }
         return;
+      case "end-broadcast":
+        if (ws === broadcaster) {
+          for (const client of wss.clients) {
+            if (client.readyState === 1 && client !== ws) {
+              client.send(JSON.stringify({ type: "bye", id: ws.id }));
+            }
+          }
+          broadcaster = null;
+          broadcastUsers();
+        }
+        return;
       case "watcher":
         if (broadcaster && broadcaster.readyState === 1) {
           broadcaster.send(JSON.stringify({ type: "watcher", id: ws.id }));


### PR DESCRIPTION
## Summary
- add media recorder for live broadcasts to capture video
- save broadcast recording with optional comment or timestamp when ending
- auto-stop stream on exit and notify watchers

## Testing
- `npm test`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_b_68ab8664558483339dacca013850c9f0