### PR TITLE
Handle video and broadcast attachments

### DIFF
--- a/index.html
+++ b/index.html
@@ -511,6 +511,9 @@
         if (file.type.startsWith('image/')) {
           msg.image = dataUrl;
           msg.name = file.name;
+        } else if (file.type.startsWith('video/')) {
+          msg.video = dataUrl;
+          msg.name = file.name;
         }
         postMessage(msg);
       };
@@ -518,13 +521,15 @@
       fileInput.value = '';
     });
 
-    function postMessage({ text='', image, file, fileName, fileType, name, isAction=false }){
+    function postMessage({ text='', image, video, broadcast, file, fileName, fileType, name, isAction=false }){
       const msg = {
         id: Date.now().toString(36) + Math.random().toString(36).slice(2,7),
         type: 'chat',
         user: store.user,
         text: text,
         image: image,
+        video: video,
+        broadcast: broadcast,
         file: file,
         fileName: fileName || name,
         fileType: fileType,
@@ -667,7 +672,7 @@
 
       bubble.appendChild(meta);
       bubble.appendChild(text);
-      const fileData = m.file || m.image;
+      const fileData = m.file || m.image || m.video || m.broadcast;
       if(fileData){
         const mime = m.fileType || ((fileData.match(/^data:(.*?);/) || [])[1] || '');
         const filename = m.fileName || m.name || '';


### PR DESCRIPTION
## Summary
- Ensure file uploads flag video attachments and forward broadcast metadata
- Include video and broadcast fields when constructing chat messages
- Render video and broadcast data alongside existing file types

## Testing
- `npm test`
- `python -m py_compile app.py db.py backup.py`


------
https://chatgpt.com/codex/tasks/task_b_68ab8f6376bc833396281261a624044b