### PR TITLE
feat: allow ending live broadcast

### DIFF
--- a/index.html
+++ b/index.html
@@ -318,7 +318,8 @@
         connectWS();
       }
     });
-    broadcastBtn.addEventListener('click', startBroadcast);
+    broadcastBtn.addEventListener('click', () => broadcasting ? endBroadcast() : startBroadcast());
+    window.addEventListener('beforeunload', () => endBroadcast(true));
 
     // --- Connection setup (optional WebSocket + local BroadcastChannel fallback) ---
     let socket = null;
@@ -550,6 +551,8 @@
       navigator.mediaDevices.getUserMedia({ video:true, audio:true }).then(stream => {
         localStream = stream;
         broadcasting = true;
+        broadcastBtn.textContent = '⏹ End';
+        broadcastBtn.title = 'End live broadcast';
         videoContainer.removeAttribute('hidden');
         const vid = document.createElement('video');
         vid.srcObject = stream;
@@ -559,6 +562,27 @@
         videoContainer.appendChild(vid);
         sendSignal({ type: 'broadcaster' });
       }).catch(() => alert('Unable to access camera/microphone'));
+    }
+
+    function endBroadcast(forced=false){
+      if(!broadcasting) return;
+      broadcasting = false;
+      broadcastBtn.textContent = '🎥 Live';
+      broadcastBtn.title = 'Go live';
+      if(localStream){
+        localStream.getTracks().forEach(t => t.stop());
+        localStream = null;
+      }
+      for(const id in peerConnections){
+        try{ peerConnections[id].close(); }catch{}
+        delete peerConnections[id];
+      }
+      sendSignal({ type: 'end-broadcast' });
+      videoContainer.innerHTML = '';
+      videoContainer.setAttribute('hidden','');
+      const note = forced ? new Date().toLocaleString() :
+        (prompt('Broadcast end comment?') || '').trim();
+      postMessage({ text: `⏹ Broadcast ended${note ? ': '+note : ''}`, broadcast: true });
     }
 
     function startWatching(){

--- a/ws-server/server.js
+++ b/ws-server/server.js
@@ -122,6 +122,17 @@ wss.on("connection", (ws) => {
           }
         }
         return;
+      case "end-broadcast":
+        if (ws === broadcaster) {
+          for (const client of wss.clients) {
+            if (client.readyState === 1 && client !== ws) {
+              client.send(JSON.stringify({ type: "bye", id: ws.id }));
+            }
+          }
+          broadcaster = null;
+          broadcastUsers();
+        }
+        return;
       case "watcher":
         if (broadcaster && broadcaster.readyState === 1) {
           broadcaster.send(JSON.stringify({ type: "watcher", id: ws.id }));


### PR DESCRIPTION
## Summary
- toggle live button between starting and ending a broadcast
- post end-of-broadcast note to feed and close stream resources
- notify watchers when broadcast ends on the WebSocket server

## Testing
- `npm test`
- `npm test --workspace ws-server` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68ac7e4a31048333b33414a46061ff22