### PR TITLE
fix: retain attachment metadata and full history

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,10 +21,16 @@ Configure this URL in the client via the "configure" button on the welcome scree
 
 ### Persistent chat history
 
-The WebSocket server stores the last 200 messages in `chat-history.json` at the
-repository root and automatically sends this history to new connections. It
-also broadcasts the number of currently connected users so the client can
-display a live online count.
+Chat messages, including attachments, are stored in the `app.db` SQLite
+database. The server sends the full history to new connections and broadcasts
+the number of currently connected users so the client can display a live online
+count.
+
+### Attachments
+
+Chat messages can include images, videos, or other files. Uploads are stored in
+the database along with the original filename and MIME type so the full post and
+its metadata are available to other users and when reloading the chat.
 
 ### File-type backups
 

--- a/app.py
+++ b/app.py
@@ -28,7 +28,6 @@ def chat_connect():
         c.execute(
             """
             SELECT user, message, image, file, file_name, file_type, timestamp FROM chat_messages
-            WHERE timestamp >= datetime('now', '-1 day')
             ORDER BY timestamp
             """
         )
@@ -60,7 +59,6 @@ def get_chat_history():
         c.execute(
             """
             SELECT user, message, image, file, file_name, file_type, timestamp FROM chat_messages
-            WHERE timestamp >= datetime('now', '-1 day')
             ORDER BY timestamp
             """
         )
@@ -123,7 +121,7 @@ def search_chat(data):
         c.execute(
             """
             SELECT user, message, image, file, file_name, file_type, timestamp FROM chat_messages
-            WHERE timestamp >= datetime('now', '-1 day') AND (message LIKE ? OR user LIKE ?)
+            WHERE message LIKE ? OR user LIKE ?
             ORDER BY timestamp
             """,
             (f'%{query}%', f'%{query}%'),


### PR DESCRIPTION
## Summary
- ensure chat client and server preserve attachment filename and MIME type
- remove history limits so full chat history is stored and served
- document SQLite-backed persistent storage in README

## Testing
- `npm test`
- `python -m py_compile app.py db.py`


------
https://chatgpt.com/codex/tasks/task_b_68ac9ac984e483339e742f2e08978838