### PR TITLE
Track viewer counts for live streams

### DIFF
--- a/index.html
+++ b/index.html
@@ -343,7 +343,12 @@
       }
     });
     broadcastBtn.addEventListener('click', () => broadcasting ? endBroadcast() : startBroadcast());
-    window.addEventListener('beforeunload', () => endBroadcast(true));
+    window.addEventListener('beforeunload', () => {
+      endBroadcast(true);
+      for(const id in streams){
+        if(streams[id].started && !streams[id].self){ endWatching(id); }
+      }
+    });
 
     // --- Connection setup (optional WebSocket + local BroadcastChannel fallback) ---
     let socket = null;
@@ -388,11 +393,12 @@
         if(streams[id]) return;
         const div = document.createElement('div');
         div.className = 'stream';
-        div.innerHTML = `<div class="title">@${name}</div><div class="video"></div><ul class="stream-feed"></ul><form class="stream-composer"><input type="text" placeholder="Comment" /><button type="submit">Send</button></form>`;
+        div.innerHTML = `<div class="title">@${name} (<span class="listener-count">0</span>)</div><div class="video"></div><ul class="stream-feed"></ul><form class="stream-composer"><input type="text" placeholder="Comment" /><button type="submit">Send</button></form>`;
         const videoBox = div.querySelector('.video');
         const feed = div.querySelector('.stream-feed');
         const form = div.querySelector('.stream-composer');
         const input = form.querySelector('input');
+        const count = div.querySelector('.listener-count');
         form.addEventListener('submit', ev => {
           ev.preventDefault();
           const text = input.value.trim();
@@ -406,10 +412,13 @@
           if(div.classList.contains('open') && !streams[id].started && !isSelf){
             startWatching(id);
             streams[id].started = true;
+          } else if(!div.classList.contains('open') && streams[id].started && !streams[id].self){
+            endWatching(id);
+            streams[id].started = false;
           }
         });
         streamsEl.appendChild(div);
-        streams[id] = { container: div, video: videoBox, feed, input, self: isSelf, started:false };
+        streams[id] = { container: div, video: videoBox, feed, input, count, self: isSelf, started:false };
       }
 
       // open stream bubble programmatically if needed
@@ -420,6 +429,10 @@
           startWatching(id);
           streams[id].started = true;
         }
+      }
+
+      function updateListenerCount(id, n){
+        if(streams[id]) streams[id].count.textContent = n;
       }
     function sendJoin(){
       try { socket && socket.readyState === 1 && socket.send(JSON.stringify({ type:'join', user: store.user })); } catch {}
@@ -465,6 +478,7 @@
             (data.messages || []).forEach(m => receive(m));
           }
           if(data && data.type === 'id') clientId = data.id;
+          if(data && data.type === 'listeners') updateListenerCount(data.id, data.count);
           if(data && data.type === 'watcher') handleWatcher(data.id);
           if(data && data.type === 'offer') handleOffer(data);
           if(data && data.type === 'answer') handleAnswer(data);
@@ -693,6 +707,10 @@
 
       function startWatching(id){
         sendSignal({ type: 'watcher', id });
+      }
+
+      function endWatching(id){
+        sendSignal({ type: 'unwatcher', id });
       }
 
     function handleWatcher(id){


### PR DESCRIPTION
## Summary
- track active listeners for each broadcaster and broadcast counts
- display per-stream listener counts and support chat replies in stream bubbles

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68aca63c7a688333b5f80621abe3a08b