### PR TITLE
fix: prevent duplicate camera streams

### DIFF
--- a/index.html
+++ b/index.html
@@ -838,6 +838,7 @@
         const pc = new RTCPeerConnection();
         peerConnections[msg.id] = pc;
         pc.ontrack = ev => {
+          if(pc._video) return; // avoid duplicate video elements per peer
           const vid = document.createElement('video');
           vid.srcObject = ev.streams[0];
           vid.autoplay = true;


### PR DESCRIPTION
## Summary
- avoid creating duplicate video elements when handling WebRTC tracks, preventing duplicated camera streams

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68acc967bb008333a500095dcc2fe8ca