### PR TITLE
Center online users panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,7 +115,7 @@
     footer { padding: 8px 18px 16px; color: var(--muted); text-align:center; font-size: 12px; }
     a { color: var(--accent-2); }
 
-    .users-panel { position:fixed; top:60px; right:20px; padding:14px; border-radius:var(--radius); background:var(--panel); border:1px solid var(--lining); box-shadow:var(--shadow); max-width:200px; max-height:60vh; overflow-y:auto; }
+    .users-panel { position:fixed; top:50%; left:50%; transform:translate(-50%,-50%); padding:14px; border-radius:var(--radius); background:var(--panel); border:1px solid var(--lining); box-shadow:var(--shadow); max-width:200px; max-height:60vh; overflow-y:auto; }
     .users-panel h3 { margin:0 0 8px; font-size:14px; }
     .users-panel ul { list-style:none; margin:0; padding:0; }
     .users-panel li { padding:4px 0; border-bottom:1px solid var(--lining); }


### PR DESCRIPTION
## Summary
- center the "Online now" user list panel to avoid overlapping with edges or other buttons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68acce291ec883339d62e92bd2db543b