### PR TITLE
Ensure chat messages table keeps attachment columns

### DIFF
--- a/db.py
+++ b/db.py
@@ -3,6 +3,15 @@ import sqlite3
 
 DB_PATH = os.environ.get("DB_PATH", "app.db")
 
+def ensure_columns(conn, table, columns):
+    c = conn.cursor()
+    c.execute(f"PRAGMA table_info({table})")
+    existing = {row[1] for row in c.fetchall()}
+    for name, definition in columns.items():
+        if name not in existing:
+            c.execute(f"ALTER TABLE {table} ADD COLUMN {name} {definition}")
+
+
 def init_db():
     with sqlite3.connect(DB_PATH) as conn:
         c = conn.cursor()
@@ -21,6 +30,24 @@ def init_db():
             )
             """
         )
+        ensure_columns(
+            conn,
+            "chat_messages",
+            {
+                "image": "TEXT",
+                "file": "TEXT",
+                "file_name": "TEXT",
+                "file_type": "TEXT",
+                "timestamp": "DATETIME DEFAULT CURRENT_TIMESTAMP",
+            },
+        )
+        # migrate legacy video column
+        c.execute("PRAGMA table_info(chat_messages)")
+        cols = {row[1] for row in c.fetchall()}
+        if "video" in cols and "file" in cols:
+            c.execute(
+                "UPDATE chat_messages SET file=video WHERE file IS NULL AND video IS NOT NULL"
+            )
         # comments
         c.execute(
             """


### PR DESCRIPTION
## Summary
- ensure chat_messages table contains columns for images, generic files, and metadata
- migrate legacy `video` column data into the new `file` column

## Testing
- `python -m py_compile db.py app.py`


------
https://chatgpt.com/codex/tasks/task_b_68ace41cfcf483338ec19e6435fe30c3