### PR TITLE
Allow all file types for mobile uploads

### DIFF
--- a/index.html
+++ b/index.html
@@ -342,7 +342,7 @@
           <label class="input" for="text">
             <input id="text" name="text" placeholder="Type a message… (try /wave, /me dance or /clear)" />
           </label>
-        <input id="file" type="file" accept="image/*,video/*,.heic,.heif,.mov" hidden />
+        <input id="file" type="file" hidden />
         <button class="send" id="attach" type="button" title="Attach file" aria-label="Attach file">📎</button>
         <button class="send" id="send" type="submit">Send</button>
         <button class="send" id="cmd-list" type="button" title="Show commands" aria-label="Show commands">📃</button>


### PR DESCRIPTION
## Summary
- Remove file type restrictions on the chat attachment input to support uploads of any format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68add460939483338f8743f02b8d6916