### PR TITLE
Start broadcast after selecting thumbnail

### DIFF
--- a/index.html
+++ b/index.html
@@ -584,13 +584,22 @@
         broadcastBtn.disabled = true;
         broadcastBtn.textContent = '⏳ Pending';
       } else {
+        const streamPromise = navigator.mediaDevices.getUserMedia({
+          video: { facingMode: usingFrontCamera ? 'user' : 'environment' },
+          audio: true
+        });
         broadcastThumb = await chooseThumbnail();
         if(broadcastThumb){
           ensureStreamThumb(clientId, store.user, true);
           handleThumbnail(clientId, broadcastThumb);
           sendSignal({ type: 'thumb', thumb: broadcastThumb });
         }
-        startBroadcast();
+        try {
+          const stream = await streamPromise;
+          startBroadcast(stream);
+        } catch {
+          alert('Unable to access camera/microphone');
+        }
       }
     });
     streamCodeBtn.addEventListener('click', () => {
@@ -1041,9 +1050,13 @@
       }
 
     // --- WebRTC helpers ---
-      function startBroadcast(){
+      function startBroadcast(stream){
         if(broadcasting) return;
-        navigator.mediaDevices.getUserMedia({ video: { facingMode: usingFrontCamera ? 'user' : 'environment' }, audio: true }).then(stream => {
+        const getStream = stream ? Promise.resolve(stream) : navigator.mediaDevices.getUserMedia({
+          video: { facingMode: usingFrontCamera ? 'user' : 'environment' },
+          audio: true
+        });
+        getStream.then(stream => {
           localStream = stream;
           recordedChunks = [];
           recordCanvas = document.createElement('canvas');


### PR DESCRIPTION
## Summary
- Begin camera capture before thumbnail selection and launch broadcast once both are ready
- Allow `startBroadcast` to use a pre-fetched media stream

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68adea3d31008333a2776d16881288d5