### PR TITLE
Restore bright-mode colors and prevent layout overflow

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,9 +29,9 @@
         --panel:#f1f5f9;
         --fg:#0f172a;
         --muted:#64748b;
-        --accent:#00c6ff;
-        --accent-2:#0072ff;
-        --shadow: 0 0 10px rgba(0,114,255,.25);
+        --accent:#ff5d6e;
+        --accent-2:#ff1f8b;
+        --shadow: 0 0 10px rgba(255,93,110,.25);
         --lining:#cbd5e1;
         --caption-color:#0f172a;
       }
@@ -39,6 +39,7 @@
     html, body { height: 100%; }
     body {
       margin:0;
+      overflow-x:hidden;
       background:
         radial-gradient(1200px 1200px at 20% -10%, color-mix(in oklab, var(--accent-2), transparent 85%), transparent 60%),
         radial-gradient(1000px 1000px at 120% 20%, color-mix(in oklab, var(--accent), transparent 88%), transparent 60%),
@@ -47,7 +48,7 @@
       font: 15px/1.45 'Poppins', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
     }
 
-    .wrap { display:grid; grid-template-rows: auto 1fr auto; height:100vh; height:100dvh; width:100%; margin:0; }
+    .wrap { display:grid; grid-template-rows: auto 1fr auto; height:100vh; height:100dvh; width:100%; max-width:100vw; margin:0 auto; }
 
     header { display:flex; align-items:center; gap:14px; padding:18px 18px; position: sticky; top: 0; z-index: 5; flex-wrap:wrap; }
     .brand { display:flex; align-items:center; gap:10px; }


### PR DESCRIPTION
## Summary
- revert light theme accents to original pinkish red palette
- hide horizontal overflow and constrain layout to viewport width

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68adf2eb2d288333b8c6065af9ca52ed