### PR TITLE
Ensure app layout fills viewport

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,18 @@
       font: 15px/1.45 'Poppins', system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
     }
 
-    .wrap { display:grid; grid-template-rows: auto 1fr auto; height:100vh; height:100dvh; width:100%; max-width:100vw; margin:0 auto; }
+    .wrap {
+      position:fixed;
+      top:0;
+      left:0;
+      right:0;
+      bottom:0;
+      display:grid;
+      grid-template-rows:auto 1fr auto;
+      width:100%;
+      max-width:100vw;
+      margin:0 auto;
+    }
 
     header { display:flex; align-items:center; gap:14px; padding:18px 18px; position: sticky; top: 0; z-index: 5; flex-wrap:wrap; }
     .brand { display:flex; align-items:center; gap:10px; }
@@ -62,11 +73,6 @@
       align-items:center;
       gap:14px;
       padding:18px;
-      position:fixed;
-      left:0;
-      right:0;
-      bottom:0;
-      z-index:5;
     }
     footer .status.bottom { justify-content:space-around; width:100%; }
     footer .status.bottom .chip { flex:1 1 25%; justify-content:center; }


### PR DESCRIPTION
## Summary
- Anchor wrapper element to viewport so entire app fits window
- Let footer sit in grid instead of fixed positioning for consistent sizing

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68adf6f98f5c833386b7410449904332