### PR TITLE
Fix broadcast video cropping by resizing to fit window

### DIFF
--- a/index.html
+++ b/index.html
@@ -280,7 +280,7 @@
       max-width: none;
       border: 0;
       border-radius: 0;
-      object-fit: cover;
+      object-fit: contain;
     }
     body.broadcast-mode #feed {
       position: fixed;


### PR DESCRIPTION
## Summary
- ensure broadcast video fits within window instead of cropping edges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68adf8bc7e9083339b4ad9a7b20313f9