### PR TITLE
Adjust chat composer placement and actions

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,8 +78,8 @@
     footer .legal { font-size:12px; color:var(--muted); text-align:center; }
     .chip { display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border:1px solid var(--lining);
             border-radius:12px; background: color-mix(in oklab, var(--panel), transparent 25%); box-shadow: var(--shadow); color: var(--fg); }
-    #live-chip, #theme-toggle, #mode-toggle { cursor:pointer; }
-    #mode-toggle, #cc-settings, #theme-toggle {
+    #live-chip, #theme-toggle, #mode-toggle, #cmd-list { cursor:pointer; }
+    #mode-toggle, #cc-settings, #theme-toggle, #cmd-list {
       width:36px;
       height:36px;
       padding:0;
@@ -153,7 +153,7 @@
 
     .system { text-align:center; color: var(--muted); font-size: 13px; margin: 12px 0; }
 
-    .composer { display:grid; grid-template-columns: minmax(0,1fr) auto auto auto; gap:10px; margin:10px 18px 12px; }
+    .composer { display:grid; grid-template-columns: minmax(0,1fr) auto auto; gap:10px; margin:10px 18px 12px; }
     .input { display:flex; align-items:center; gap:10px; padding:10px 12px; border-radius: 12px; background: var(--panel); border:1px solid var(--lining); box-shadow: var(--shadow); }
     .input input { flex:1; font: inherit; color: var(--fg); background: transparent; border:0; outline:0; }
     .input input::placeholder { color: color-mix(in oklab, var(--muted), transparent 10%); }
@@ -365,17 +365,16 @@
 
       <main>
         <div id="streams" class="streams"></div>
+        <div id="video-container" hidden></div>
+        <ul id="feed" class="feed" aria-live="polite" aria-busy="false"></ul>
         <form id="composer" class="composer" autocomplete="off">
           <label class="input" for="text">
             <input id="text" name="text" placeholder="Type a message… (try /wave, /me dance or /clear)" />
           </label>
-        <input id="file" type="file" hidden />
-        <button class="send" id="attach" type="button" title="Attach file" aria-label="Attach file">📎</button>
-        <button class="send" id="send" type="submit" aria-label="Send message">🐒</button>
-        <button class="send" id="cmd-list" type="button" title="Show commands" aria-label="Show commands">📃</button>
-      </form>
-        <div id="video-container" hidden></div>
-        <ul id="feed" class="feed" aria-live="polite" aria-busy="false"></ul>
+          <input id="file" type="file" hidden />
+          <button class="send" id="attach" type="button" title="Attach file" aria-label="Attach file">📎</button>
+          <button class="send" id="send" type="submit" aria-label="Send message">🐒</button>
+        </form>
       </main>
 
     <footer>
@@ -385,6 +384,7 @@
           <span id="live-count">0</span> online
         </span>
         <button id="theme-toggle" class="chip" title="Toggle dark or light mode"></button>
+        <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands">📃</button>
         <span class="chip" id="user-chip" title="Logged in user" style="display:none">
           <span class="usr" id="user-name"></span>
           <button id="logout-btn" class="btn ghost" style="padding:6px 10px" type="button">Logout</button>


### PR DESCRIPTION
## Summary
- Position composer at bottom of main content above footer controls
- Move command list button into footer beside theme toggle and style uniformly
- Simplify composer grid layout for three items

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae0e98f2dc833397661ae86ab74d12