### PR TITLE
Reload local history when switching to local mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -925,6 +925,7 @@
       else if(mode === 'local'){ connDot.classList.add('local'); connLabel.textContent = 'Online (Local)'; updateUsers([]); }
       else { connDot.classList.add('off'); connLabel.textContent = 'Offline'; updateUsers([]); }
       modeToggle.textContent = mode === 'cloud' ? 'Go Local' : 'Go Cloud';
+      if(mode !== 'cloud') renderHistory();
     }
 
     function connectWS(){


### PR DESCRIPTION
## Summary
- Reload stored chat history whenever the app leaves cloud mode so the "Go Cloud/Go Local" toggle shows local messages immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae2593b1888333933ddd874dfa78d3