### PR TITLE
Fix local and cloud mode transitions

### DIFF
--- a/index.html
+++ b/index.html
@@ -632,18 +632,25 @@
         try { v ? localStorage.setItem('chaines_obs_key', v) : localStorage.removeItem('chaines_obs_key'); }
         catch {}
       },
-      pushMsg(m) {
+      pushMsg(m, mode='local') {
         try {
-          const items = JSON.parse(localStorage.getItem('chaines_messages') || '[]');
+          const key = mode === 'cloud' ? 'chaines_cloud_messages' : 'chaines_messages';
+          const items = JSON.parse(localStorage.getItem(key) || '[]');
           items.push(m); while (items.length > 200) items.shift();
-          localStorage.setItem('chaines_messages', JSON.stringify(items));
+          localStorage.setItem(key, JSON.stringify(items));
         } catch {}
       },
-      loadMsgs() {
-        try { return JSON.parse(localStorage.getItem('chaines_messages') || '[]'); } catch { return []; }
+      loadMsgs(mode='local') {
+        try {
+          const key = mode === 'cloud' ? 'chaines_cloud_messages' : 'chaines_messages';
+          return JSON.parse(localStorage.getItem(key) || '[]');
+        } catch { return []; }
       },
-      clearMsgs() {
-        try { localStorage.removeItem('chaines_messages'); } catch {}
+      clearMsgs(mode='local') {
+        try {
+          const key = mode === 'cloud' ? 'chaines_cloud_messages' : 'chaines_messages';
+          localStorage.removeItem(key);
+        } catch {}
       }
     };
 
@@ -666,6 +673,7 @@
         socket = null;
         setStatus(bc ? 'local' : 'off');
       } else {
+        setStatus('cloud');
         connectWS();
       }
     });
@@ -943,11 +951,25 @@
     function setStatus(mode){
       onlineMode = mode;
       connDot.classList.remove('ok','local','off');
-      if(mode === 'cloud'){ connDot.classList.add('ok'); connLabel.textContent = 'Online (Cloud)'; }
-      else if(mode === 'local'){ connDot.classList.add('local'); connLabel.textContent = 'Online (Local)'; updateUsers([]); }
-      else { connDot.classList.add('off'); connLabel.textContent = 'Offline'; updateUsers([]); }
+      if(mode === 'cloud'){
+        connDot.classList.add('ok');
+        connLabel.textContent = 'Online (Cloud)';
+        updateUsers([]);
+        renderHistory('cloud');
+      }
+      else if(mode === 'local'){
+        connDot.classList.add('local');
+        connLabel.textContent = 'Online (Local)';
+        updateUsers([]);
+        renderHistory('local');
+      }
+      else {
+        connDot.classList.add('off');
+        connLabel.textContent = 'Offline';
+        updateUsers([]);
+        renderHistory('local');
+      }
       modeToggle.textContent = mode === 'cloud' ? 'Go Local' : 'Go Cloud';
-      if(mode !== 'cloud') renderHistory();
     }
 
     function connectWS(){
@@ -971,7 +993,6 @@
           if(data && data.type === 'users') updateUsers(data.users || []);
           if(data && data.type === 'count') liveCount.textContent = data.count;
           if(data && data.type === 'history') {
-            store.clearMsgs();
             feed.innerHTML = '';
             (data.messages || []).forEach(m => receive(m));
           }
@@ -997,7 +1018,7 @@
       if(!('BroadcastChannel' in window)) { setStatus('off'); return; }
       bc = new BroadcastChannel('chaines_chat');
       bc.onmessage = (ev) => {
-        const m = ev.data; if(m && m.type === 'chat') receive(m);
+        const m = ev.data; if(m && m.type === 'chat') receive(m, 'local');
       };
       if(onlineMode !== 'cloud') setStatus('local');
     }
@@ -1070,7 +1091,16 @@
 
       if(raw){
         // Commands
-        if(raw === '/clear'){ store.clearMsgs(); feed.innerHTML=''; input.value=''; input.placeholder = defaultPlaceholder; pendingFile=null; systemNote('Cleared local chat history.'); return; }
+        if(raw === '/clear'){
+          const key = onlineMode === 'cloud' ? 'cloud' : 'local';
+          store.clearMsgs(key);
+          feed.innerHTML='';
+          input.value='';
+          input.placeholder = defaultPlaceholder;
+          pendingFile=null;
+          systemNote(`Cleared ${key} chat history.`);
+          return;
+        }
         if(/^\s*\/me\s+/.test(raw)){
           const act = raw.replace(/^\s*\/me\s+/, '');
           postMessage({ text: `*${act}*`, isAction:true });
@@ -1157,8 +1187,8 @@
       };
 
       // Push to UI + storage immediately
-        receive(msg, true);
-        if(!room) store.pushMsg(msg);
+        const modeKey = onlineMode === 'cloud' ? 'cloud' : 'local';
+        receive(msg, modeKey);
 
       // Broadcast locally
       try { bc && bc.postMessage(msg); } catch {}
@@ -1491,7 +1521,7 @@
       try { socket && socket.readyState === 1 && socket.send(JSON.stringify(data)); } catch {}
     }
 
-      function receive(m, isLocal=false){
+      function receive(m, mode='cloud'){
         if(!m || seen.has(m.id)) return;
         seen.add(m.id);
         if(m.room){
@@ -1499,14 +1529,14 @@
           if(streams[m.room]) appendStreamMessage(streams[m.room], m);
         } else {
           appendMessage(m);
-          if(!isLocal) store.pushMsg(m);
+          store.pushMsg(m, mode);
         }
       }
 
-      function renderHistory(){
+      function renderHistory(mode = onlineMode === 'cloud' ? 'cloud' : 'local'){
       feed.innerHTML = '';
-      const items = store.loadMsgs();
-      items.slice().reverse().forEach(m => appendMessage(m, true));
+      const items = store.loadMsgs(mode);
+      items.slice().reverse().forEach(m => { seen.add(m.id); appendMessage(m, true); });
       scrollToTop();
     }
 


### PR DESCRIPTION
## Summary
- Maintain separate local and cloud chat histories
- Render the appropriate message history when switching modes
- Clear command removes history only for the current mode

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68ae2e890b348333999cb6da6230e36b