### PR TITLE
Pin chat feed messages to top

### DIFF
--- a/static/chat.js
+++ b/static/chat.js
@@ -88,8 +88,8 @@
           msg.appendChild(link);
         }
       }
-      feed.appendChild(msg);
-      feed.scrollTop = feed.scrollHeight;
+      feed.insertBefore(msg, feed.firstChild);
+      feed.scrollTop = 0;
     }
     function renderMessages(list){
       feed.innerHTML = '';


### PR DESCRIPTION
## Summary
- Show newest chat messages at the top of the chat feed
- Reset scroll position so older messages drop downward

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68ae3653caac8333a57dc534db377080