### PR TITLE
Improve profile placement and auth overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -67,18 +67,6 @@
     .status .chip { flex:1 1 auto; justify-content:center; }
     header .chip { padding:4px 8px; }
     header .status.top { margin-left:auto; justify-content:flex-end; }
-    #profile-btn {
-      width:32px;
-      height:32px;
-      padding:0;
-      border:1px solid var(--lining);
-      border-radius:8px;
-      overflow:hidden;
-      background: color-mix(in oklab, var(--panel), transparent 25%);
-      box-shadow: var(--shadow);
-      display:none;
-    }
-    #profile-btn img { width:100%; height:100%; object-fit:cover; border-radius:8px; }
     footer {
       display:flex;
       flex-direction:column;
@@ -193,7 +181,7 @@
     .send:disabled { opacity:.6; cursor:not-allowed; }
 
     /* Auth screen */
-    .auth { position: fixed; inset:0; display:flex; align-items:center; justify-content:center; background: linear-gradient(180deg, rgba(0,0,0,.65), rgba(0,0,0,.65)); backdrop-filter: blur(4px); overflow:hidden; }
+    .auth { position: fixed; left:0; right:0; top:0; bottom:0; display:flex; align-items:center; justify-content:center; background: linear-gradient(180deg, rgba(0,0,0,.65), rgba(0,0,0,.65)); backdrop-filter: blur(4px); overflow:auto; }
     .card { width:min(520px, 92vw); padding:22px; border-radius: 18px; background: var(--panel); border: 1px solid var(--lining); box-shadow: var(--shadow); }
     .card h2 { margin:0 0 8px; font-size: 22px; }
     .card p { margin: 0 0 14px; color: var(--muted); }
@@ -390,10 +378,12 @@
         <button class="chip" id="fullscreen-btn" title="Toggle fullscreen">⛶ Fullscreen</button>
         <button id="mode-toggle" class="chip" title="Switch between cloud or local modes"></button>
         <button id="cc-settings" class="chip" title="Caption settings">CC</button>
-        <button id="profile-btn" title="Profile" style="display:none">
-          <img id="profile-top" alt="avatar" />
-        </button>
       </div>
+      <span class="chip" id="user-chip" title="Logged in user" style="display:none">
+        <img id="user-avatar" alt="avatar" style="width:24px;height:24px;border-radius:50%;object-fit:cover;display:none;margin-right:4px;" />
+        <span class="usr" id="user-name"></span>
+        <button id="logout-btn" class="btn ghost" style="padding:6px 10px" type="button">Logout</button>
+      </span>
     </header>
     <div id="cc-panel" class="cc-panel" hidden>
       <label>Font
@@ -432,11 +422,6 @@
         </span>
         <button id="theme-toggle" class="chip" title="Toggle dark or light mode"></button>
         <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands">📃</button>
-        <span class="chip" id="user-chip" title="Logged in user" style="display:none">
-          <img id="user-avatar" alt="avatar" style="width:24px;height:24px;border-radius:50%;object-fit:cover;display:none;margin-right:4px;" />
-          <span class="usr" id="user-name"></span>
-          <button id="logout-btn" class="btn ghost" style="padding:6px 10px" type="button">Logout</button>
-        </span>
       </div>
       <div class="legal">© <span id="year"></span> CHAINeS • Built for <a href="https://chaines.io" target="_blank" rel="noopener">chaines.io</a></div>
     </footer>
@@ -548,9 +533,12 @@
     const userChip = el('#user-chip');
     const userName = el('#user-name');
     const userAvatar = el('#user-avatar');
-    const profileBtn = el('#profile-btn');
-    const profileTop = el('#profile-top');
     const logoutBtn = el('#logout-btn');
+    [userAvatar, userName].forEach(u => u.addEventListener('click', () => {
+      if(store.user){
+        location.href = '/profile.html?user=' + encodeURIComponent(store.user);
+      }
+    }));
     const connDot = el('#conn-dot');
     const connLabel = el('#conn-label');
     const connChip = el('#conn-chip');
@@ -1044,6 +1032,10 @@
         auth.hidden = false;
         auth.classList.remove('is-hidden');
         auth.style.display = 'flex';
+        const top = headerBar.offsetHeight;
+        const bottom = footerBar.offsetHeight;
+        auth.style.top = top + 'px';
+        auth.style.bottom = bottom + 'px';
         document.body.classList.add('auth-lock');
         setTimeout(() => usernameInput && usernameInput.focus(), 50);
       }
@@ -1058,13 +1050,9 @@
       if(store.profilePic){
         userAvatar.src = store.profilePic;
         userAvatar.style.display = 'block';
-        profileTop.src = store.profilePic;
-        profileTop.style.display = 'block';
       } else {
         userAvatar.style.display = 'none';
-        profileTop.style.display = 'none';
       }
-      profileBtn.style.display = 'inline-flex';
 
       document.body.classList.remove('auth-lock');
       document.documentElement.style.zoom = '1';
@@ -1131,9 +1119,6 @@
     }));
 
     logoutBtn.addEventListener('click', (e) => { e.preventDefault(); store.user=''; store.profilePic=''; location.reload(); });
-    profileBtn.addEventListener('click', () => {
-      location.href = '/profile.html?user=' + encodeURIComponent(store.user);
-    });
 
     wsEdit.addEventListener('click', () => {
       wsCfg.style.display = wsCfg.style.display==='none' ? 'grid' : 'none';

--- a/profile.html
+++ b/profile.html
@@ -77,7 +77,13 @@ textarea{width:100%;min-height:80px;border-radius:8px;border:1px solid var(--lin
 
   picInput.addEventListener('change', () => {
     if (picInput.files[0]) {
-      avatar.src = URL.createObjectURL(picInput.files[0]);
+      const file = picInput.files[0];
+      avatar.src = URL.createObjectURL(file);
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        localStorage.setItem('chaines_profile_pic', e.target.result);
+      };
+      reader.readAsDataURL(file);
     }
   });
 


### PR DESCRIPTION
## Summary
- Place user profile chip in header opposite the logo
- Constrain login overlay between header and footer
- Update profile picture preview and storage when selecting new image

## Testing
- `npm test`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68af21782ea88333be48cc7c319fa959