### PR TITLE
Organize footer icons into balanced groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -78,9 +78,15 @@
       z-index:5;
     }
     footer .status.bottom {
-      display:grid;
-      grid-template-columns:repeat(6,1fr);
+      display:flex;
       width:100%;
+      gap:8px;
+    }
+    footer .status.bottom .group {
+      flex:1;
+      display:grid;
+      grid-template-columns:repeat(2,1fr);
+      grid-template-rows:repeat(2,1fr);
       gap:8px;
     }
     footer .status.bottom .chip {
@@ -428,19 +434,23 @@
       </form>
       <input id="file" type="file" hidden />
       <div class="status bottom">
-        <button class="chip" id="broadcast-btn" title="Go live">🎥 Live</button>
-        <span class="chip" id="live-chip" title="Users online">
-          <span id="live-count">0</span> online
-        </span>
-        <button id="theme-toggle" class="chip" title="Toggle dark or light mode"></button>
-        <button id="mutual-btn" class="chip" title="Mutual messages">💬</button>
-        <button id="analytics-btn" class="chip" title="Analytics">🔋</button>
-        <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands">⚡</button>
-        <span class="chip" id="user-chip" title="Logged in user" style="display:none">
-          <img id="user-avatar" alt="avatar" style="width:24px;height:24px;border-radius:50%;object-fit:cover;display:none;margin-right:4px;" />
-          <span class="usr" id="user-name"></span>
-        </span>
-        <button id="logout-btn" class="chip" style="display:none" type="button">Logout</button>
+        <div class="group left">
+          <button class="chip" id="broadcast-btn" title="Go live">🎥 Live</button>
+          <span class="chip" id="live-chip" title="Users online">
+            <span id="live-count">0</span> online
+          </span>
+          <span class="chip" id="user-chip" title="Logged in user" style="display:none">
+            <img id="user-avatar" alt="avatar" style="width:24px;height:24px;border-radius:50%;object-fit:cover;display:none;margin-right:4px;" />
+            <span class="usr" id="user-name"></span>
+          </span>
+          <button id="logout-btn" class="chip" style="display:none" type="button">Logout</button>
+        </div>
+        <div class="group right">
+          <button id="analytics-btn" class="chip" title="Analytics">🔋</button>
+          <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands">⚡</button>
+          <button id="theme-toggle" class="chip" title="Toggle dark or light mode"></button>
+          <button id="mutual-btn" class="chip" title="Mutual messages">💬</button>
+        </div>
       </div>
       <div class="legal">© <span id="year"></span> CHAINeS • Built for <a href="https://chaines.io" target="_blank" rel="noopener">chaines.io</a></div>
     </footer>


### PR DESCRIPTION
## Summary
- Group footer controls into left and right blocks of four buttons
- Add grid-based layout so sun and chat icons sit beneath battery and lightning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68af3bfaaaa88333b9b2604383fee499