### PR TITLE
Add hologhost button to footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -82,8 +82,8 @@
     footer .legal { font-size:12px; color:var(--muted); text-align:center; }
     .chip { display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border:1px solid var(--lining);
             border-radius:12px; background: color-mix(in oklab, var(--panel), transparent 25%); box-shadow: var(--shadow); color: var(--fg); }
-    #live-chip, #theme-toggle, #mode-toggle, #cmd-list { cursor:pointer; }
-    #mode-toggle, #cc-settings, #theme-toggle, #cmd-list {
+    #live-chip, #theme-toggle, #mode-toggle, #cmd-list, #ghost-btn { cursor:pointer; }
+    #mode-toggle, #cc-settings, #theme-toggle, #cmd-list, #ghost-btn {
       width:36px;
       height:36px;
       padding:0;
@@ -95,6 +95,11 @@
       border:0;
       color:#05130e;
     }
+    #ghost-btn {
+      background: linear-gradient(180deg, var(--accent), var(--accent-2));
+      border:0;
+    }
+    #ghost-btn img { width:24px; height:24px; }
     .dot { width:10px; height:10px; border-radius:999px; background:var(--muted); }
     .dot.ok { background: var(--accent); }
     .dot.local { background: #ffb020; }
@@ -429,6 +434,9 @@
         </span>
         <button id="logout-btn" class="chip" type="button" title="Logout">Logout</button>
         <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands">⚡</button>
+        <button id="ghost-btn" class="chip" title="Hologhost" aria-label="Hologhost">
+          <img src="static/hologhost.svg" alt="Hologhost" />
+        </button>
       </div>
       <div class="legal">© <span id="year"></span> CHAINeS • Built for <a href="https://chaines.io" target="_blank" rel="noopener">chaines.io</a></div>
     </footer>

--- a/static/hologhost.svg
+++ b/static/hologhost.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" fill="none">
+  <defs>
+    <linearGradient id="grad" x1="32" y1="0" x2="32" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0%" stop-color="#00c6ff"/>
+      <stop offset="100%" stop-color="#0072ff"/>
+    </linearGradient>
+  </defs>
+  <path d="M32 4c-12.15 0-22 9.85-22 22v26l6-4 6 4 6-4 6 4 6-4 6 4V26c0-12.15-9.85-22-22-22z" fill="url(#grad)" stroke="#002b6b" stroke-width="2"/>
+  <circle cx="22" cy="26" r="4" fill="#fff"/>
+  <circle cx="42" cy="26" r="4" fill="#fff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add hologhost SVG asset
- show new hologhost button in footer status panel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68af52846d60833398f39b4f5410beab