### PR TITLE
Adjust broadcast layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -319,15 +319,16 @@
     }
     body.broadcast-mode #feed {
       position: fixed;
-      bottom: 80px;
-      left: 0;
+      inset: 0;
       width: 100%;
-      height: 33vh;
+      height: 100%;
       margin: 0;
       border-radius: 0;
-      background: rgba(0,0,0,0.3);
-      backdrop-filter: blur(4px);
+      background: rgba(0,0,0,0.05);
       z-index: 1001;
+    }
+    body.broadcast-mode #composer {
+      display: none;
     }
     body.broadcast-mode header {
       position: fixed;


### PR DESCRIPTION
## Summary
- Expand broadcast chat overlay to cover entire video with nearly transparent background
- Hide main chat composer when broadcasting so only reactions remain

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68af6c78c4f08333a8e9847bb50e68fa