### PR TITLE
Refactor header with icon control bar

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
     .status { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
     .status .chip { flex:1 1 auto; justify-content:center; }
     header .chip { padding:4px 8px; }
-    header .status.top { margin-left:auto; justify-content:flex-end; }
+    header .status.icon-bar { flex:1 0 100%; width:100%; }
     footer {
       display:flex;
       flex-direction:column;
@@ -79,13 +79,11 @@
       bottom:0;
       z-index:5;
     }
-    footer .status.bottom { display:flex; flex-wrap:wrap; width:100%; gap:8px; align-items:center; }
-    footer .status.bottom .chip { display:flex; justify-content:center; }
     footer .legal { font-size:12px; color:var(--muted); text-align:center; }
     .chip { display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border:1px solid var(--lining);
             border-radius:12px; background: color-mix(in oklab, var(--panel), transparent 25%); box-shadow: var(--shadow); color: var(--fg); }
-    #live-chip, #theme-toggle, #mode-toggle, #cmd-list, #ghost-btn { cursor:pointer; }
-    #mode-toggle, #theme-toggle, #cmd-list, #ghost-btn {
+    #live-chip, #theme-toggle, #mode-toggle, #cmd-list, #ghost-btn, #broadcast-btn, #logout-btn, #user-chip { cursor:pointer; }
+    #mode-toggle, #theme-toggle, #cmd-list, #ghost-btn, #broadcast-btn, #logout-btn, #user-chip {
       width:36px;
       height:36px;
       padding:0;
@@ -184,9 +182,8 @@
 
     .system { text-align:center; color: var(--muted); font-size: 13px; margin: 12px 0; }
 
-    .composer { display:grid; grid-template-columns: minmax(0,1fr) 56px; gap:10px; margin:0; width:100%; }
-    #composer { grid-template-columns: minmax(0,1fr) repeat(4,56px); }
-    .input { display:flex; align-items:center; gap:10px; padding:10px 12px; border-radius: 12px; background: var(--panel); border:2px solid var(--accent); box-shadow: var(--shadow); }
+    .composer { display:flex; gap:10px; margin:0; width:100%; }
+    .input { display:flex; align-items:center; gap:10px; flex:1; padding:10px 12px; border-radius: 12px; background: var(--panel); border:2px solid var(--accent); box-shadow: var(--shadow); }
     .input input { flex:1; font: inherit; color: var(--fg); background: transparent; border:0; outline:0; }
     .input input::placeholder { color: color-mix(in oklab, var(--muted), transparent 10%); }
     .send { display:flex; align-items:center; justify-content:center; width:56px; height:56px; font-size:24px; border-radius:12px; border:2px solid var(--accent-2); font-weight:700; cursor:pointer; color:#05130e; background: linear-gradient(180deg, var(--accent), var(--accent-2)); box-shadow: var(--shadow); }
@@ -343,7 +340,7 @@
       padding: 8px;
       gap: 0;
     }
-    body.broadcast-mode footer .status.bottom,
+    body.broadcast-mode header .icon-bar,
     body.broadcast-mode footer .legal {
       display: none;
     }
@@ -504,8 +501,6 @@
         </label>
         <button id="mode-toggle" class="chip" title="Switch between cloud or local modes"></button>
         <button id="theme-toggle" class="chip" title="Toggle dark or light mode"></button>
-      </div>
-      <div class="status top">
         <div class="chip" id="invite-cc">
           <button id="stream-code-btn" type="button" title="Copy stream code">🔑 Stream Code</button>
           <button id="camera-flip-btn" type="button" title="Switch camera">🔁 Flip</button>
@@ -513,6 +508,20 @@
           <button id="end-btn" type="button" title="End broadcast" hidden>⏹ End</button>
           <button id="listener-count" type="button" title="Active listeners">0 listening</button>
         </div>
+      </div>
+      <div class="status icon-bar">
+        <button class="chip" id="broadcast-btn" title="Go live" aria-label="Go live">🎥</button>
+        <span class="chip" id="live-chip" title="Users online">👥 <span id="live-count">0</span></span>
+        <button id="ghost-btn" class="chip" type="button" title="Hologhost" aria-label="Hologhost">
+          <img src="static/hologhost.svg" alt="Hologhost" />
+        </button>
+        <button class="chip" id="user-chip" type="button" title="Profile" aria-label="Profile">
+          <img id="user-avatar" alt="avatar" style="width:24px;height:24px;border-radius:50%;object-fit:cover;display:none;" />
+          <span id="user-icon">👤</span>
+          <span id="user-name" style="display:none">@guest</span>
+        </button>
+        <button id="logout-btn" class="chip" type="button" title="Logout" aria-label="Logout">🚪</button>
+        <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands">⚡</button>
       </div>
     </header>
 
@@ -530,9 +539,6 @@
         </label>
         <button class="send" id="attach" type="button" aria-label="Attach file">📎</button>
         <button class="send" id="send" type="submit" aria-label="Send message">🐒</button>
-        <button class="send" id="ghost-btn" type="button" title="Hologhost" aria-label="Hologhost">
-          <img src="static/hologhost.svg" alt="Hologhost" />
-        </button>
       </form>
       <input id="file" type="file" hidden />
       <div class="broadcast-controls" id="broadcast-controls" hidden>
@@ -545,18 +551,6 @@
         </label>
         <button class="send" id="broadcast-send" type="submit" aria-label="Send broadcast message">🐒</button>
       </form>
-      <div class="status bottom">
-        <button class="chip" id="broadcast-btn" title="Go live">🎥 Live</button>
-        <span class="chip" id="live-chip" title="Users online">
-          <span id="live-count">0</span> online
-        </span>
-        <span class="chip" id="user-chip" title="Logged in user">
-          <img id="user-avatar" alt="avatar" style="width:24px;height:24px;border-radius:50%;object-fit:cover;display:none;margin-right:4px;" />
-          <span class="usr" id="user-name">@guest</span>
-        </span>
-        <button id="logout-btn" class="chip" type="button" title="Logout">Logout</button>
-        <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands">⚡</button>
-      </div>
       <div class="legal">© <span id="year"></span> CHAINeS • Built for <a href="https://chaines.io" target="_blank" rel="noopener">chaines.io</a></div>
     </footer>
   </div>
@@ -668,8 +662,9 @@
     const userChip = el('#user-chip');
     const userName = el('#user-name');
     const userAvatar = el('#user-avatar');
+    const userIcon = el('#user-icon');
     const logoutBtn = el('#logout-btn');
-    [userAvatar, userName].forEach(u => u.addEventListener('click', () => {
+    [userAvatar, userIcon, userName].forEach(u => u && u.addEventListener('click', () => {
       if(store.user){
         location.href = '/profile.html?user=' + encodeURIComponent(store.user);
       }
@@ -1229,8 +1224,10 @@
       if(store.profilePic){
         userAvatar.src = store.profilePic;
         userAvatar.style.display = 'block';
+        userIcon.style.display = 'none';
       } else {
         userAvatar.style.display = 'none';
+        userIcon.style.display = 'block';
       }
 
       document.body.classList.remove('auth-lock');


### PR DESCRIPTION
## Summary
- Move live, online count, ghost, profile, logout and command buttons into a single header bar of icons
- Show a profile icon fallback when no avatar is set

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68afb1edd2b483339226ac3442b30bca