### PR TITLE
Refactor toolbar with branded icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     .brand { display:flex; align-items:center; gap:10px; }
     .brand .logo { width:32px; height:32px; border-radius:8px; background: url('static/logo.svg') no-repeat center/cover; box-shadow: var(--shadow); }
     .brand h1 { font-weight: 800; letter-spacing:.4px; font-size: 16px; margin:0; }
-    .toolbar { display:flex; align-items:center; gap:8px; }
+    .toolbar { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
     .self-destruct { display:flex; align-items:center; gap:4px; font-size:12px; }
     .self-destruct input { accent-color: var(--accent-2); }
     .status { display:flex; align-items:center; gap:8px; width:100%; }
@@ -108,7 +108,7 @@
       flex:1 1 auto;
       width:100%;
     }
-    #invite-cc button {
+    #invite-cc button { 
       flex:1;
       border:0;
       padding:0 10px;
@@ -120,31 +120,7 @@
       height:100%;
     }
     #invite-cc button + button { border-left:1px solid var(--lining); }
-    #user-cc {
-      display:flex;
-      flex-wrap:wrap;
-      padding:0;
-      border-radius:12px;
-      overflow:hidden;
-      min-height:36px;
-      flex:1 1 auto;
-      width:100%;
-    }
-    #user-cc > * {
-      flex:1 1 50%;
-      border:0;
-      padding:0 6px;
-      background: color-mix(in oklab, var(--panel), transparent 25%);
-      color: var(--fg);
-      display:flex;
-      align-items:center;
-      justify-content:center;
-      height:100%;
-      text-decoration:none;
-      white-space:nowrap;
-    }
-    #user-cc > * + * { border-left:1px solid var(--lining); }
-    #profile-link { justify-content:flex-start; gap:4px; }
+    #profile-link { display:inline-flex; align-items:center; gap:4px; }
     #profile-link img { width:24px; height:24px; border-radius:50%; }
     #end-btn {
       background: var(--danger);
@@ -539,6 +515,10 @@
             <input type="checkbox" id="auto-delete" />
             Self-destruct in 5m
           </label>
+            <span id="conn-chip" class="chip" title="Connection status"><span class="conn-dot off" id="conn-dot"></span><span id="conn-label">Offline</span></span>
+            <span id="live-chip" class="chip" title="Users active">👤 <span id="live-count">0</span></span>
+            <a id="profile-link" class="chip" href="/profile.html">Profile</a>
+            <button id="logout-btn" class="chip" type="button" title="Logout">Logout</button>
           <button id="mode-toggle" class="chip" title="Switch between cloud or local modes"><img src="static/cloud.svg" alt="Toggle mode" /></button>
           <button id="theme-toggle" class="chip" title="Toggle dark or light mode"><img src="static/sun.svg" alt="Toggle theme" /></button>
           <button id="ghost-btn" class="chip" type="button" title="Hologhost" aria-label="Hologhost"><img src="static/hologhost.svg" alt="Hologhost" /></button>
@@ -551,14 +531,6 @@
           <button id="invite-btn" type="button" title="Invite listeners">📢 Invite</button>
           <button id="end-btn" type="button" title="End broadcast" hidden>⏹ End</button>
           <button id="listener-count" type="button" title="Active listeners">0 listening</button>
-        </div>
-      </div>
-      <div class="status user">
-        <div class="chip" id="user-cc">
-          <span id="conn-chip" title="Connection status"><span class="conn-dot off" id="conn-dot"></span><span id="conn-label">Offline</span></span>
-          <span id="live-chip" title="Users active">👤 <span id="live-count">0</span> users active</span>
-          <a id="profile-link" href="/profile.html">Profile</a>
-          <button id="logout-btn" type="button" title="Logout">Logout</button>
         </div>
       </div>
     </header>

--- a/static/cloud.svg
+++ b/static/cloud.svg
@@ -1,3 +1,11 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M20 17.5A4.5 4.5 0 0017 9h-.1A6 6 0 005 11a4 4 0 000 8h15z"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="cloudGrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#00c6ff"/>
+      <stop offset="100%" stop-color="#e0eafc"/>
+    </linearGradient>
+  </defs>
+  <path d="M20 17.5A4.5 4.5 0 0017 9h-.1A6 6 0 005 11a4 4 0 000 8h15z"
+        fill="url(#cloudGrad)" stroke="#e2e8f0" stroke-width="1.5"
+        stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/static/sun.svg
+++ b/static/sun.svg
@@ -1,11 +1,19 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-  <circle cx="12" cy="12" r="5"/>
-  <line x1="12" y1="1" x2="12" y2="3"/>
-  <line x1="12" y1="21" x2="12" y2="23"/>
-  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-  <line x1="1" y1="12" x2="3" y2="12"/>
-  <line x1="21" y1="12" x2="23" y2="12"/>
-  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <defs>
+    <linearGradient id="sunGrad" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#e0eafc"/>
+      <stop offset="100%" stop-color="#00c6ff"/>
+    </linearGradient>
+  </defs>
+  <circle cx="12" cy="12" r="5" fill="url(#sunGrad)" stroke="#e2e8f0" stroke-width="1.5"/>
+  <g stroke="#00c6ff" stroke-width="1.5" stroke-linecap="round">
+    <line x1="12" y1="1" x2="12" y2="3"/>
+    <line x1="12" y1="21" x2="12" y2="23"/>
+    <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+    <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+    <line x1="1" y1="12" x2="3" y2="12"/>
+    <line x1="21" y1="12" x2="23" y2="12"/>
+    <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+    <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+  </g>
 </svg>


### PR DESCRIPTION
## Summary
- collapse profile and active user info into the main toolbar
- add branded gradient cloud and sun icons in cool blue-silver tones

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b06b2507988333b9b8d0535fd7996a