### PR TITLE
Move header toolbar icons into second row

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,7 +64,7 @@
     .brand { display:flex; align-items:center; gap:10px; }
     .brand .logo { width:32px; height:32px; border-radius:8px; background: url('static/logo.svg') no-repeat center/cover; box-shadow: var(--shadow); }
     .brand h1 { font-weight: 800; letter-spacing:.4px; font-size: 16px; margin:0; }
-    .toolbar { display:flex; align-items:center; gap:8px; flex-wrap:nowrap; overflow-x:auto; }
+    .toolbar { display:flex; align-items:center; gap:8px; flex-wrap:wrap; justify-content:center; padding:6px; border:1px solid var(--lining); border-radius:var(--radius); background: color-mix(in oklab, var(--panel), transparent 25%); }
     .toolbar .chip { flex:0 0 auto; }
     .self-destruct { display:flex; align-items:center; gap:4px; font-size:12px; }
     .self-destruct input { accent-color: var(--accent-2); }
@@ -507,25 +507,25 @@
 <body>
   <div class="wrap">
     <header>
-      <div class="bar">
-        <div class="brand">
-          <div class="logo" aria-hidden="true"></div>
-          <h1>CHAINeS Chat</h1>
-        </div>
-        <div class="toolbar">
+        <div class="bar">
+          <div class="brand">
+            <div class="logo" aria-hidden="true"></div>
+            <h1>CHAINeS Chat</h1>
+          </div>
           <label class="self-destruct" title="Auto-delete your posts after 5 minutes">
             <input type="checkbox" id="auto-delete" />
             Self-destruct in 5m
           </label>
-            <span id="conn-chip" class="chip" title="Connection status"><span class="conn-dot off" id="conn-dot"></span><span id="conn-label">Offline</span></span>
-            <span id="live-chip" class="chip" title="Users active"><img src="static/user.svg" alt="Users" /><span id="live-count">0</span></span>
-            <a id="profile-link" class="chip" href="/profile.html"><img id="profile-pic" src="static/user.svg" alt="Profile" hidden><span id="profile-name">Profile</span></a>
-            <button id="logout-btn" class="chip" type="button" title="Logout" aria-label="Logout"><img src="static/logout.svg" alt="Logout" /></button>
+        </div>
+        <div class="toolbar">
+          <span id="conn-chip" class="chip" title="Connection status"><span class="conn-dot off" id="conn-dot"></span><span id="conn-label">Offline</span></span>
+          <span id="live-chip" class="chip" title="Users active"><img src="static/user.svg" alt="Users" /><span id="live-count">0</span></span>
+          <a id="profile-link" class="chip" href="/profile.html"><img id="profile-pic" src="static/user.svg" alt="Profile" hidden><span id="profile-name">Profile</span></a>
+          <button id="logout-btn" class="chip" type="button" title="Logout" aria-label="Logout"><img src="static/logout.svg" alt="Logout" /></button>
           <button id="mode-toggle" class="chip" title="Switch between cloud or local modes"><img src="static/cloud.svg" alt="Toggle mode" /></button>
           <button id="theme-toggle" class="chip" title="Toggle dark or light mode"><img src="static/sun.svg" alt="Toggle theme" /></button>
           <button id="ghost-btn" class="chip" type="button" title="Hologhost" aria-label="Hologhost"><img src="static/hologhost.svg" alt="Hologhost" /></button>
         </div>
-      </div>
       <div class="status top">
         <div class="chip" id="invite-cc">
           <button id="stream-code-btn" type="button" title="Copy stream code">🔑 Stream Code</button>


### PR DESCRIPTION
## Summary
- Place header icons in a second-row toolbar below the self-destruct toggle
- Center and wrap toolbar icons for tighter, evenly spaced layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0705093e48333b33c7eaa3531f9ee