### PR TITLE
Fix broadcast termination when guests join or use mic

### DIFF
--- a/index.html
+++ b/index.html
@@ -1798,6 +1798,8 @@
         updateVideoLayout();
       }
       startBroadcast();
+      // Clear pending host to avoid unintended broadcast termination
+      pendingJoinHost = null;
     }
 
     function handleJoinDenied(){
@@ -1825,6 +1827,8 @@
         updateVideoLayout();
       }
       startBroadcast(null, true);
+      // Clear pending mic host to ensure the broadcast persists
+      pendingMicHost = null;
     }
 
     function handleMicDenied(){


### PR DESCRIPTION
## Summary
- Clear pending host tracking after join approval to keep both broadcasters live
- Clear pending mic host tracking after mic approval so audio-only guests stay broadcasting

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b07f75ed948333b1d61928251d1c81