### PR TITLE
fix: ensure guests join host stream when approved

### DIFF
--- a/index.html
+++ b/index.html
@@ -1838,6 +1838,10 @@
       const stream = streams[pendingJoinHost];
       if(stream && stream.requestBtn) stream.requestBtn.disabled = true;
       broadcastBtn.disabled = false;
+      if(stream && !stream.started){
+        startWatching(pendingJoinHost);
+        stream.started = true;
+      }
       const hostVid = stream && stream.video.querySelector('video');
       if(hostVid){
         videoContainer.appendChild(hostVid);


### PR DESCRIPTION
## Summary
- make guests watch host stream when join request approved before starting broadcast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b08777f8f88333bd2e7b2a56784e83