### PR TITLE
Serve logo as root favicon

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,8 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover" />
   <title>CHAINeS Chat</title>
-  <link rel="icon" href="static/logo.svg" type="image/svg+xml" />
-  <link rel="apple-touch-icon" href="static/logo.svg" />
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  <link rel="apple-touch-icon" href="/favicon.svg" />
   <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600;700&display=swap" rel="stylesheet">
   <meta name="color-scheme" content="dark light" />
   <script type="module" src="https://unpkg.com/@google/model-viewer/dist/model-viewer.min.js"></script>

--- a/profile.html
+++ b/profile.html
@@ -4,7 +4,8 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>User Profile</title>
-<link rel="icon" href="static/logo.svg" type="image/svg+xml" />
+<link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+<link rel="apple-touch-icon" href="/favicon.svg" />
 <style>
 :root {
   --bg: #0f172a;

--- a/ws-server/server.js
+++ b/ws-server/server.js
@@ -83,6 +83,13 @@ const upload = multer({ storage });
 
 app.use("/static", express.static(path.join(ROOT, "static")));
 
+app.get("/favicon.ico", (req, res) => res.redirect(301, "/favicon.svg"));
+app.get("/favicon.svg", (req, res) =>
+  res
+    .type("image/svg+xml")
+    .sendFile(path.join(ROOT, "static", "logo.svg"))
+);
+
 app.get("/healthz", (req, res) => res.send("ok"));
 app.get(["/", "/index.html"], (req, res) =>
   res.sendFile(path.join(ROOT, "index.html"))


### PR DESCRIPTION
## Summary
- serve `/favicon.svg` from `static/logo.svg` and redirect `/favicon.ico`
- reference root favicon in HTML pages for consistent branding

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b08f75d1dc833386f38a17d3fabacd