### PR TITLE
Add camera and layout toggles to broadcast screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -97,7 +97,8 @@
       justify-content:center;
       border-radius:12px;
     }
-    #conn-chip img, #theme-toggle img, #ghost-btn img, #logout-btn img, #live-chip img {
+    #conn-chip img, #theme-toggle img, #ghost-btn img, #logout-btn img, #live-chip img,
+    #camera-btn img, #split-btn img {
       width:24px;
       height:24px;
     }
@@ -615,8 +616,12 @@
       <input id="file" type="file" hidden />
       <div class="broadcast-controls" id="broadcast-controls" hidden>
         <button class="chip" id="chat-toggle" type="button">💬 Chat</button>
-        <button class="chip" id="swap-btn" type="button" hidden>🔀 Swap</button>
-        <button class="chip" id="split-btn" type="button" hidden>🪟 Split</button>
+        <button class="chip" id="camera-btn" type="button" hidden title="Toggle camera">
+          <img src="static/camera.svg" alt="Toggle camera" />
+        </button>
+        <button class="chip" id="split-btn" type="button" hidden title="Split view">
+          <img src="static/split.svg" alt="Split layout" />
+        </button>
         <button class="chip" id="exit-broadcast" type="button">Exit</button>
       </div>
       <form id="broadcast-composer" class="composer" autocomplete="off" hidden>
@@ -764,7 +769,7 @@
     const exitBroadcast = el('#exit-broadcast');
     const broadcastControls = el('#broadcast-controls');
     const chatToggle = el('#chat-toggle');
-    const swapBtn = el('#swap-btn');
+    const cameraBtn = el('#camera-btn');
     const splitBtn = el('#split-btn');
     const broadcastComposer = el('#broadcast-composer');
     const broadcastInput = el('#broadcast-text');
@@ -805,12 +810,16 @@
       document.body.classList.toggle('chat-open');
     });
 
-    if(swapBtn){
-      swapBtn.addEventListener('click', swapVideos);
+    if(cameraBtn){
+      cameraBtn.addEventListener('click', swapVideos);
     }
     if(splitBtn){
       splitBtn.addEventListener('click', () => {
         splitMode = !splitMode;
+        const icon = splitBtn.querySelector('img');
+        icon.src = splitMode ? 'static/split.svg' : 'static/insert.svg';
+        icon.alt = splitMode ? 'Split layout' : 'Insert layout';
+        splitBtn.title = splitMode ? 'Split view' : 'Insert view';
         updateVideoLayout();
       });
     }
@@ -1750,7 +1759,7 @@
           if(multi){
             vids.forEach(v => v.onclick = swapVideos);
           }
-          if(swapBtn) swapBtn.hidden = !multi;
+          if(cameraBtn) cameraBtn.hidden = !multi;
           if(splitBtn) splitBtn.hidden = !multi;
         }
       }

--- a/static/camera.svg
+++ b/static/camera.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="7" width="13" height="10" rx="2" ry="2" />
+  <polygon points="16,9 21,7 21,17 16,15" />
+</svg>

--- a/static/insert.svg
+++ b/static/insert.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="5" width="18" height="14" rx="1" ry="1" />
+  <rect x="11" y="11" width="8" height="6" rx="1" ry="1" />
+</svg>

--- a/static/split.svg
+++ b/static/split.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="3" y="5" width="8" height="14" rx="1" ry="1" />
+  <rect x="13" y="5" width="8" height="14" rx="1" ry="1" />
+</svg>


### PR DESCRIPTION
## Summary
- add camera toggle button to swap between host and guest video
- add split/insert toggle with custom SVG icons
- update layout logic and styles for new controls

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b0922f9d1c8333b8cf8995dfd62d73