### PR TITLE
Fix split view to display host and guest cameras

### DIFF
--- a/index.html
+++ b/index.html
@@ -836,8 +836,22 @@
         icon.alt = splitMode ? 'Split layout' : 'Insert layout';
         splitBtn.title = splitMode ? 'Split view' : 'Insert view';
         updateVideoLayout();
+        for(const id in streams){
+          if(streams[id] && streams[id].video){
+            updateVideoLayout(streams[id].video);
+          }
+        }
       });
     }
+
+    window.addEventListener('resize', () => {
+      updateVideoLayout();
+      for(const id in streams){
+        if(streams[id] && streams[id].video){
+          updateVideoLayout(streams[id].video);
+        }
+      }
+    });
 
     // --- Basic state ---
     const store = {


### PR DESCRIPTION
## Summary
- Update split layout toggle to refresh all active video containers so host and invited broadcaster share one window
- Recalculate video layout on window resize to resolve viewport issues across devices

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0b0dcd8a483338fadee363e47ec64