### PR TITLE
fix: include audio in canvas recording

### DIFF
--- a/index.html
+++ b/index.html
@@ -1626,6 +1626,7 @@
             draw();
             try {
               const canvasStream = recordCanvas.captureStream(30);
+              stream.getAudioTracks().forEach(track => canvasStream.addTrack(track));
               const mime = MediaRecorder.isTypeSupported('video/mp4;codecs=avc1') ? 'video/mp4' : 'video/webm';
               mediaRecorder = new MediaRecorder(canvasStream, { mimeType: mime });
               recordMime = mime;


### PR DESCRIPTION
## Summary
- ensure mic audio is preserved by attaching media stream audio tracks to the canvas capture when starting a broadcast

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0bc63b7b88333941aca02b1af5b58