### PR TITLE
Fix duplicate video display and persist layout toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -1874,7 +1874,7 @@
             vids.forEach(v => v.onclick = swapVideos);
           }
           if(swapBtn) swapBtn.hidden = !(broadcasting && multi);
-          if(splitBtn) splitBtn.hidden = !(broadcasting && multi);
+          if(splitBtn) splitBtn.hidden = !broadcasting;
         }
       }
 
@@ -1914,6 +1914,7 @@
           pc = new RTCPeerConnection();
           peerConnections[msg.id] = pc;
           pc.ontrack = ev => {
+            if(ev.track.kind !== 'video') return;
             const vid = document.createElement('video');
             vid.srcObject = ev.streams[0];
             vid.autoplay = true;


### PR DESCRIPTION
## Summary
- Only render remote video elements when a video track is present to avoid duplicate feeds
- Keep split/PiP toggle visible for broadcasters regardless of guest count

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b0ce3759108333b3c7fa0c92715382