### PR TITLE
Show guest camera instead of duplicating broadcaster

### DIFF
--- a/index.html
+++ b/index.html
@@ -2042,6 +2042,7 @@
       const ok = confirm(`Allow @${user || 'user'} to join?`);
       sendSignal({ type: ok ? 'approve-join' : 'deny-join', id });
       if(ok){
+        postMessage({ text: `@${user || 'user'} joined the broadcast`, broadcast: true, isAction:true });
         setTimeout(() => startWatching(id), 1000);
       }
     }
@@ -2096,7 +2097,7 @@
       alert('Mic request denied.');
     }
 
-    function handleGuestStart({ id, host }){
+    function handleGuestStart({ id, host, user }){
       guestMap[id] = host;
       if(streams[id]){
         streams[id].container.remove();
@@ -2105,11 +2106,8 @@
       const hostStream = streams[host];
       if(hostStream){
         hostStream.container.classList.add('open');
-        if(!hostStream.started){
-          startWatching(host);
-          hostStream.started = true;
-        }
         startWatching(id);
+        systemNote(`@${user || 'user'} joined the broadcast`);
       }
     }
 

--- a/ws-server/server.js
+++ b/ws-server/server.js
@@ -403,15 +403,22 @@ wss.on("connection", (ws) => {
         broadcasters.set(ws.id, ws);
         broadcastUsers();
         const hostId = guestHosts.get(ws.id);
-        if(hostId){
+        if (hostId) {
+          const payload = JSON.stringify({
+            type: "guest-start",
+            host: hostId,
+            id: ws.id,
+            user: ws.username || null,
+          });
           const set = listeners.get(hostId);
-          if(set){
-            const payload = JSON.stringify({ type: "guest-start", host: hostId, id: ws.id });
-            for(const wid of set){
+          if (set) {
+            for (const wid of set) {
               const watcher = clients.get(wid);
-              if(watcher && watcher.readyState === 1) watcher.send(payload);
+              if (watcher && watcher.readyState === 1) watcher.send(payload);
             }
           }
+          const hostSock = clients.get(hostId);
+          if (hostSock && hostSock.readyState === 1) hostSock.send(payload);
         }
         return;
       case "mic-broadcaster":


### PR DESCRIPTION
## Summary
- Broadcast guest-start to host and watchers with username for proper camera swap
- Add note when host approves a guest and start watching their feed
- Display guest camera in second slot instead of duplicating broadcaster

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b0d6dc14dc83339fcca5de3404fefe