### PR TITLE
Style broadcast tile without flex

### DIFF
--- a/index.html
+++ b/index.html
@@ -384,10 +384,62 @@
       cursor:pointer;
     }
     .tune-btn:disabled { opacity:.5; cursor:not-allowed; }
-    #video-container { display:flex; flex-wrap:wrap; gap:10px; padding:10px; justify-content:center; }
-    #video-container video { max-width:240px; border-radius:12px; border:1px solid var(--lining); }
-    .video-canvas { position:relative; flex:1 1 50%; display:flex; align-items:center; justify-content:center; }
-    .video-canvas video { width:100%; height:100%; object-fit:contain; }
+    #video-container {
+      position: relative;
+      max-width: 640px;
+      margin: 0 auto;
+      border: 1px solid var(--lining);
+      border-radius: 12px;
+      background: var(--panel);
+      overflow: hidden;
+    }
+    #video-container video {
+      width: 100%;
+      height: 100%;
+      aspect-ratio: 16/9;
+      object-fit: cover;
+      display: block;
+    }
+    .video-canvas {
+      position: relative;
+    }
+    #video-container.has-guest {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+    }
+    #video-container.has-guest #host-canvas,
+    #video-container.has-guest #guest-canvas {
+      width: 100%;
+      height: 100%;
+    }
+    @media (orientation: portrait) {
+      #video-container.has-guest {
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr 1fr;
+      }
+    }
+    #video-container.pip {
+      display: block;
+    }
+    #video-container.pip #host-canvas {
+      width: 100%;
+      height: 100%;
+    }
+    #video-container.pip #guest-canvas {
+      position: absolute;
+      width: 30%;
+      height: 30%;
+      bottom: 10px;
+      right: 10px;
+      border: 2px solid #fff;
+      border-radius: 8px;
+      overflow: hidden;
+    }
+    #video-container.pip #guest-canvas video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
 
     #overlay-chat {
       position: fixed;
@@ -456,24 +508,6 @@
     }
     .broadcast-controls .chip { flex:1; }
     body.broadcast-mode .broadcast-controls { display:flex; }
-    body.broadcast-mode #video-container {
-      position: fixed;
-      inset: 0;
-      z-index: 1000;
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      background: #000;
-    }
-    body.broadcast-mode #video-container video {
-      width: 100%;
-      height: 100%;
-      max-width: 100%;
-      max-height: 100%;
-      border: 0;
-      border-radius: 0;
-      object-fit: contain;
-    }
     body.broadcast-mode #feed {
       position: fixed;
       left: 0;
@@ -521,50 +555,6 @@
       color: #fff;
     }
     body.broadcast-mode #feed .meta { color: #ddd; }
-    body.broadcast-mode #video-container.has-guest {
-      display: flex;
-    }
-    body.broadcast-mode #video-container.has-guest #host-canvas,
-    body.broadcast-mode #video-container.has-guest #guest-canvas {
-      width: 50%;
-      height: 100%;
-      max-width: 50%;
-      max-height: 100%;
-    }
-    @media (orientation: portrait) {
-      body.broadcast-mode #video-container.has-guest {
-        flex-direction: column;
-      }
-      body.broadcast-mode #video-container.has-guest #host-canvas,
-      body.broadcast-mode #video-container.has-guest #guest-canvas {
-        width: 100%;
-        height: 50%;
-        max-width: 100%;
-        max-height: 50%;
-      }
-    }
-
-    body.broadcast-mode #video-container.pip {
-      display: block;
-    }
-    body.broadcast-mode #video-container.pip #host-canvas {
-      width: 100%;
-      height: 100%;
-      max-width: 100%;
-      max-height: 100%;
-    }
-    body.broadcast-mode #video-container.pip #guest-canvas {
-      position: absolute;
-      width: 30%;
-      height: 30%;
-      bottom: 10px;
-      right: 10px;
-      border: 2px solid #fff;
-      border-radius: 8px;
-      max-width: none;
-      max-height: none;
-      overflow: hidden;
-    }
 
     #thumb-chooser {
       position: fixed;


### PR DESCRIPTION
## Summary
- Replace broadcast area flex layout with grid-based tile container
- Add picture-in-picture and guest split styles using grid

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b22817defc8333b2a86be1140b45a5