### PR TITLE
Align guest camera with broadcast container

### DIFF
--- a/index.html
+++ b/index.html
@@ -1603,7 +1603,7 @@
       }
 
     // --- WebRTC helpers ---
-      function startBroadcast(stream, audioOnly=false){
+      function startBroadcast(stream, audioOnly=false, asGuest=false){
         if(broadcasting) return;
         overlayMessages = [];
         cameraOff = false;
@@ -1714,10 +1714,10 @@
               try{ speechRec.start(); }catch{}
             }
           }
-          const hostCanvas = el('#host-canvas');
-          if(hostCanvas){
-            hostCanvas.innerHTML = '';
-            hostCanvas.appendChild(mediaEl);
+          const canvas = el(asGuest ? '#guest-canvas' : '#host-canvas');
+          if(canvas){
+            canvas.innerHTML = '';
+            canvas.appendChild(mediaEl);
           } else {
             videoContainer.appendChild(mediaEl);
           }
@@ -2083,7 +2083,18 @@
         startWatching(pendingJoinHost);
         stream.started = true;
       }
-      startBroadcast();
+      const hostVid = stream && stream.video.querySelector('video');
+      if(hostVid){
+        const hostCanvas = el('#host-canvas');
+        if(hostCanvas){
+          hostCanvas.innerHTML = '';
+          hostCanvas.appendChild(hostVid);
+        } else {
+          videoContainer.appendChild(hostVid);
+        }
+        updateVideoLayout();
+      }
+      startBroadcast(null, false, true);
       // Keep pendingJoinHost so chat stays in host room
     }
 
@@ -2108,10 +2119,16 @@
       if(stream && stream.micBtn) stream.micBtn.disabled = true;
       const hostVid = stream && stream.video.querySelector('video');
       if(hostVid){
-        videoContainer.appendChild(hostVid);
+        const hostCanvas = el('#host-canvas');
+        if(hostCanvas){
+          hostCanvas.innerHTML = '';
+          hostCanvas.appendChild(hostVid);
+        } else {
+          videoContainer.appendChild(hostVid);
+        }
         updateVideoLayout();
       }
-      startBroadcast(null, true);
+      startBroadcast(null, true, true);
       // Clear pending mic host to ensure the broadcast persists
       pendingMicHost = null;
     }


### PR DESCRIPTION
## Summary
- Place guest and host cameras in shared broadcast container
- Support picture-in-picture and split screen without overlap

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b22b1eeb3883338cd7422f19e4927a