### PR TITLE
Improve broadcast layout for full-screen broadcasts

### DIFF
--- a/index.html
+++ b/index.html
@@ -408,6 +408,25 @@
       object-fit: cover;
       display: block;
     }
+
+    body.broadcast-mode #video-container {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100vw;
+      height: 100vh;
+      margin: 0;
+      max-width: none;
+      border: 0;
+      border-radius: 0;
+    }
+    body.broadcast-mode #video-container video {
+      object-fit: contain;
+    }
+
+    body.broadcast-mode #overlay-chat {
+      bottom: 70px;
+    }
     .video-canvas {
       position: relative;
     }
@@ -451,6 +470,22 @@
       width: 100%;
       height: 100%;
       object-fit: cover;
+    }
+
+    #video-container.three {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+    }
+    #video-container.three video {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+    @media (orientation: portrait) {
+      #video-container.three {
+        grid-template-columns: 1fr;
+        grid-template-rows: repeat(3, 1fr);
+      }
     }
 
     #overlay-chat {
@@ -546,20 +581,9 @@
       z-index: 1002;
       background: rgba(0,0,0,0.03);
     }
+    body.broadcast-mode #stream-tiles { display:none; }
     body.broadcast-mode header {
-      position: fixed;
-      top: 0;
-      left: 0;
-      width: 100%;
-      background: rgba(0,0,0,0.3);
-      backdrop-filter: blur(4px);
-      z-index: 1003;
-    }
-    body.broadcast-mode header .brand { display:none; }
-    body.broadcast-mode header .status.top { width:100%; justify-content:center; }
-    body.broadcast-mode header .chip {
-      background: rgba(0,0,0,0.6);
-      border-color: rgba(255,255,255,0.2);
+      display: none;
     }
     body.broadcast-mode #feed .bubble {
       background: rgba(0,0,0,0.6);
@@ -1917,6 +1941,7 @@
           if(layoutMode === 'guest' && vids[0]) vids[0].style.display = 'none';
           container.classList.toggle('has-guest', multi && layoutMode === 'split');
           container.classList.toggle('pip', multi && layoutMode === 'pip');
+          container.classList.toggle('three', vids.length === 3 && layoutMode === 'split');
           const guestCanvas = el('#guest-canvas');
           if(guestCanvas) guestCanvas.hidden = guestCanvas.querySelectorAll('video').length === 0;
           vids.forEach(v => v.onclick = null);
@@ -1928,6 +1953,7 @@
         } else {
           container.classList.toggle('has-guest', multi && layoutMode === 'split');
           container.classList.toggle('pip', multi && layoutMode === 'pip');
+          container.classList.toggle('three', vids.length === 3 && layoutMode === 'split');
         }
       }
 


### PR DESCRIPTION
## Summary
- Make broadcast video container span full screen and overlay chat higher
- Hide header and stream tiles while broadcasting
- Add three-camera grid support and toggle in layout logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2381755a48333b366babe0002be13