### PR TITLE
Add control toggle and responsive video tiles

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,8 +93,8 @@
     footer .legal { font-size:12px; color:var(--muted); text-align:center; }
     .chip { display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border:1px solid var(--lining);
             border-radius:12px; background: color-mix(in oklab, var(--panel), transparent 25%); box-shadow: var(--shadow); color: var(--fg); backdrop-filter: blur(8px); }
-    #live-chip, #theme-toggle, #cmd-list, #ghost-btn, #logout-btn, #conn-chip, #camera-btn, #swap-btn { cursor:pointer; }
-    #theme-toggle, #cmd-list, #ghost-btn, #logout-btn, #camera-btn, #swap-btn {
+    #live-chip, #theme-toggle, #cmd-list, #ghost-btn, #logout-btn, #conn-chip, #camera-btn, #swap-btn, #controls-toggle { cursor:pointer; }
+    #theme-toggle, #cmd-list, #ghost-btn, #logout-btn, #camera-btn, #swap-btn, #controls-toggle {
       width:36px;
       height:36px;
       padding:0;
@@ -431,22 +431,23 @@
       position: relative;
     }
     #video-container.has-guest {
-      display: flex;
-      flex-direction: row;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
     }
     #video-container.has-guest #host-canvas,
     #video-container.has-guest #guest-canvas {
-      width: 50%;
+      width: 100%;
       height: 100%;
     }
     @media (orientation: portrait) {
       #video-container.has-guest {
-        flex-direction: column;
+        grid-template-columns: 1fr;
+        grid-template-rows: 1fr 1fr;
       }
       #video-container.has-guest #host-canvas,
       #video-container.has-guest #guest-canvas {
         width: 100%;
-        height: 50%;
+        height: 100%;
       }
     }
     #video-container.pip {
@@ -626,6 +627,18 @@
       font-size: 1rem;
     }
 
+    #controls-toggle {
+      position: fixed;
+      top: 8px;
+      right: 8px;
+      z-index: 10;
+    }
+
+    body.controls-hidden header,
+    body.controls-hidden footer {
+      display: none;
+    }
+
     /* ✅ make hidden actually hide, even with .auth display rules */
     [hidden] { display: none !important; }
     .auth.is-hidden { display: none !important; }
@@ -638,6 +651,7 @@
   </style>
 </head>
 <body>
+  <button id="controls-toggle" class="chip" type="button" title="Toggle controls">🎛</button>
   <div class="wrap">
     <header>
                 <div class="bar">
@@ -849,6 +863,7 @@
     const exitBroadcast = el('#exit-broadcast');
     const broadcastControls = el('#broadcast-controls');
     const chatToggle = el('#chat-toggle');
+    const controlsToggle = el('#controls-toggle');
     const cameraBtn = el('#camera-btn');
     const broadcastComposer = el('#broadcast-composer');
     const broadcastInput = el('#broadcast-text');
@@ -895,6 +910,12 @@
     chatToggle.addEventListener('click', () => {
       document.body.classList.toggle('chat-open');
     });
+
+    if(controlsToggle){
+      controlsToggle.addEventListener('click', () => {
+        document.body.classList.toggle('controls-hidden');
+      });
+    }
 
     if(cameraBtn){
       cameraBtn.addEventListener('click', toggleCamera);
@@ -1934,11 +1955,13 @@
 
       function updateVideoLayout(container = videoContainer){
         const vids = container.querySelectorAll('video');
-        const multi = vids.length > 1;
         if(container === videoContainer){
+          if(vids.length) container.removeAttribute('hidden');
+          else container.setAttribute('hidden','');
           vids.forEach(v => v.style.display = '');
           if(layoutMode === 'self' && vids[1]) vids[1].style.display = 'none';
           if(layoutMode === 'guest' && vids[0]) vids[0].style.display = 'none';
+          const multi = vids.length > 1;
           container.classList.toggle('has-guest', multi && layoutMode === 'split');
           container.classList.toggle('pip', multi && layoutMode === 'pip');
           container.classList.toggle('three', vids.length === 3 && layoutMode === 'split');
@@ -1951,6 +1974,7 @@
           if(swapBtn) swapBtn.hidden = !multi;
           if(swapBtn) swapBtn.title = layoutTitles[layoutMode];
         } else {
+          const multi = vids.length > 1;
           container.classList.toggle('has-guest', multi && layoutMode === 'split');
           container.classList.toggle('pip', multi && layoutMode === 'pip');
           container.classList.toggle('three', vids.length === 3 && layoutMode === 'split');


### PR DESCRIPTION
## Summary
- Add floating controls toggle button to hide or show interface buttons
- Display broadcaster and guest as responsive tiles with grid layout for desktop and stacked layout on mobile
- Automatically reveal video container when streams are present so viewers always see the broadcast

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b23ef8c668833386b57f395b1f8141