### PR TITLE
Show broadcast join requests in chat feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -2086,11 +2086,19 @@
       }
 
     function handleJoinRequest(id, user){
-      const ok = confirm(`Allow @${user || 'user'} to join?`);
-      sendSignal({ type: ok ? 'approve-join' : 'deny-join', id });
-      if(ok){
-        setTimeout(() => startWatching(id), 1000);
-      }
+      const li = document.createElement('li');
+      li.className = 'system';
+      li.innerHTML = `@${user || 'user'} wants to join. <button class="accept">Accept</button> <button class="deny">Deny</button>`;
+      feed.insertBefore(li, feed.firstChild);
+      li.querySelector('.accept').addEventListener('click', () => {
+        sendSignal({ type: 'approve-join', id });
+        startWatching(id);
+        li.remove();
+      });
+      li.querySelector('.deny').addEventListener('click', () => {
+        sendSignal({ type: 'deny-join', id });
+        li.remove();
+      });
     }
 
     function handleJoinApproved(){
@@ -2117,8 +2125,18 @@
     }
 
     function handleMicRequest(id, user){
-      const ok = confirm(`Allow @${user || 'user'} to speak?`);
-      sendSignal({ type: ok ? 'approve-mic' : 'deny-mic', id });
+      const li = document.createElement('li');
+      li.className = 'system';
+      li.innerHTML = `@${user || 'user'} wants to speak. <button class="accept">Accept</button> <button class="deny">Deny</button>`;
+      feed.insertBefore(li, feed.firstChild);
+      li.querySelector('.accept').addEventListener('click', () => {
+        sendSignal({ type: 'approve-mic', id });
+        li.remove();
+      });
+      li.querySelector('.deny').addEventListener('click', () => {
+        sendSignal({ type: 'deny-mic', id });
+        li.remove();
+      });
     }
 
     function handleMicApproved(){


### PR DESCRIPTION
## Summary
- Replace confirmation dialogs for broadcast join and mic requests with chat feed messages.
- Allow hosts to accept or deny requests directly in the chat feed and auto-start watching on approval.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b25c12a8e08333affcf13dfca3aa5c