### PR TITLE
Auto-open live streams for active users

### DIFF
--- a/index.html
+++ b/index.html
@@ -368,28 +368,6 @@
     .stream-composer { display:none; margin-top:4px; gap:4px; }
     .stream.open .stream-composer { display:flex; }
     .stream-composer input { flex:1; }
-    .request-btn {
-      margin-top:4px;
-      width:100%;
-      padding:4px;
-      border:1px solid var(--lining);
-      border-radius:8px;
-      background:color-mix(in oklab, var(--panel), transparent 10%);
-      color:var(--fg);
-      cursor:pointer;
-    }
-    .request-btn:disabled { opacity:.5; cursor:not-allowed; }
-    .tune-btn {
-      margin-top:4px;
-      width:100%;
-      padding:4px;
-      border:1px solid var(--lining);
-      border-radius:8px;
-      background:color-mix(in oklab, var(--panel), transparent 10%);
-      color:var(--fg);
-      cursor:pointer;
-    }
-    .tune-btn:disabled { opacity:.5; cursor:not-allowed; }
     #video-container {
       position: relative;
       max-width: 640px;
@@ -1177,7 +1155,7 @@
         if(streams[id]) return;
         const div = document.createElement('div');
         div.className = 'stream';
-        div.innerHTML = `<div class="title">@${name} (<span class="listener-count">0</span>)</div><img class="thumb" alt="thumbnail" /><div class="video"></div>${isSelf ? '' : '<button class="tune-btn" type="button">Tune In</button><button class="request-btn" type="button">Request Camera</button><button class="request-mic-btn" type="button">Request Mic</button>'}<ul class="stream-feed"></ul><form class="stream-composer"><input type="text" placeholder="Comment" /><button type="submit">Send</button></form>`;
+        div.innerHTML = `<div class="title">@${name} (<span class="listener-count">0</span>)</div><img class="thumb" alt="thumbnail" /><div class="video"></div><ul class="stream-feed"></ul><form class="stream-composer"><input type="text" placeholder="Comment" /><button type="submit">Send</button></form>`;
         const videoBox = div.querySelector('.video');
         const thumbEl = div.querySelector('.thumb');
         thumbEl.setAttribute('hidden','');
@@ -1185,9 +1163,6 @@
         const form = div.querySelector('.stream-composer');
         const input = form.querySelector('input');
         const count = div.querySelector('.listener-count');
-        const reqBtn = div.querySelector('.request-btn');
-        const micBtn = div.querySelector('.request-mic-btn');
-        const tuneBtn = div.querySelector('.tune-btn');
         form.addEventListener('submit', ev => {
           ev.preventDefault();
           const text = input.value.trim();
@@ -1195,51 +1170,25 @@
           postMessage({ text, room: id });
           input.value='';
         });
-        if(reqBtn){
-          reqBtn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            pendingJoinHost = id;
-            joinApproved = false;
-            reqBtn.disabled = true;
-            sendSignal({ type: 'join-request', id, user: store.user });
-          });
-        }
-        if(micBtn){
-          micBtn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            pendingMicHost = id;
-            micApproved = false;
-            micBtn.disabled = true;
-            sendSignal({ type: 'mic-request', id, user: store.user });
-          });
-        }
-        if(tuneBtn){
-          tuneBtn.addEventListener('click', ev => {
-            ev.stopPropagation();
-            div.classList.add('open');
-            if(!streams[id].started){
-              startWatching(id);
-              streams[id].started = true;
-            }
-            tuneBtn.disabled = true;
-          });
-        }
         div.addEventListener('click', e => {
           if(e.target.closest('form')) return;
           div.classList.toggle('open');
           if(div.classList.contains('open') && !streams[id].started && !isSelf){
             startWatching(id);
             streams[id].started = true;
-            if(streams[id].tuneBtn) streams[id].tuneBtn.disabled = true;
           } else if(!div.classList.contains('open') && streams[id].started && !streams[id].self){
             endWatching(id);
             streams[id].started = false;
-            if(streams[id].tuneBtn) streams[id].tuneBtn.disabled = false;
           }
         });
         if(pendingThumbs[id]){ thumbEl.src = pendingThumbs[id]; thumbEl.removeAttribute('hidden'); delete pendingThumbs[id]; }
         (isSelf ? selfStreamEl : streamsEl).appendChild(div);
-        streams[id] = { container: div, video: videoBox, feed, input, count, self: isSelf, started:false, requestBtn: reqBtn, micBtn, tuneBtn, vid: null, captionTrack: null, thumbEl };
+        streams[id] = { container: div, video: videoBox, feed, input, count, self: isSelf, started:false, vid: null, captionTrack: null, thumbEl };
+        div.classList.add('open');
+        if(!isSelf){
+          startWatching(id);
+          streams[id].started = true;
+        }
       }
       function chooseThumbnail(){
         return new Promise(resolve => {
@@ -1824,12 +1773,6 @@
       updateHeaderButtons();
       joinApproved = false;
       micApproved = false;
-      if(pendingJoinHost && streams[pendingJoinHost] && streams[pendingJoinHost].requestBtn){
-        streams[pendingJoinHost].requestBtn.disabled = false;
-      }
-      if(pendingMicHost && streams[pendingMicHost] && streams[pendingMicHost].micBtn){
-        streams[pendingMicHost].micBtn.disabled = false;
-      }
       pendingJoinHost = null;
       pendingMicHost = null;
       broadcastBtn.disabled = false;
@@ -2070,7 +2013,7 @@
             streams[msg.id].started = false;
             streams[msg.id].video.innerHTML = '';
             streams[msg.id].container.classList.remove('open');
-            if(streams[msg.id].tuneBtn) streams[msg.id].tuneBtn.disabled = false;
+            // no tune button to enable
             streams[msg.id].vid = null;
             streams[msg.id].captionTrack = null;
             updateVideoLayout(streams[msg.id].video);
@@ -2104,7 +2047,6 @@
     function handleJoinApproved(){
       joinApproved = true;
       const stream = streams[pendingJoinHost];
-      if(stream && stream.requestBtn) stream.requestBtn.disabled = true;
       broadcastBtn.disabled = false;
       if(stream && !stream.started){
         startWatching(pendingJoinHost);
@@ -2117,7 +2059,6 @@
     function handleJoinDenied(){
       joinApproved = false;
       const stream = streams[pendingJoinHost];
-      if(stream && stream.requestBtn) stream.requestBtn.disabled = false;
       pendingJoinHost = null;
       broadcastBtn.disabled = false;
       broadcastBtn.textContent = '🎥 Go Live';
@@ -2142,7 +2083,6 @@
     function handleMicApproved(){
       micApproved = true;
       const stream = streams[pendingMicHost];
-      if(stream && stream.micBtn) stream.micBtn.disabled = true;
       const hostVid = stream && stream.video.querySelector('video');
       if(hostVid){
         videoContainer.appendChild(hostVid);
@@ -2156,7 +2096,6 @@
     function handleMicDenied(){
       micApproved = false;
       const stream = streams[pendingMicHost];
-      if(stream && stream.micBtn) stream.micBtn.disabled = false;
       pendingMicHost = null;
       alert('Mic request denied.');
     }


### PR DESCRIPTION
## Summary
- Show live camera streams automatically in the scrolling user section
- Remove tune/request/mic buttons and start watching streams immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b25d934b088333a5e0d8af8a19737c