### PR TITLE
Broadcast invite notifications in chat feed

### DIFF
--- a/index.html
+++ b/index.html
@@ -2117,11 +2117,17 @@
       }
     }
 
-    function handleInvite({ id, mode, user }){
+    function handleInvite({ id, mode, user }) {
       const verb = mode === 'mic' ? 'join via mic' : 'join the broadcast';
-      appendMessage({ id: `invite-${Date.now()}`, user: user || 'host', text: `invites you to ${verb}.` });
+      const msg = { id: `invite-${Date.now()}`, user: user || 'host', text: `invites you to ${verb}.` };
+      const stream = streams[id];
+      if (stream && stream.feed) {
+        appendMessage(msg, false, stream.feed);
+      } else {
+        appendMessage(msg);
+      }
       const ok = confirm(`@${user || 'host'} invites you to ${verb}. Accept?`);
-      if(ok){
+      if (ok) {
         sendSignal({ type: mode === 'mic' ? 'mic-request' : 'join-request', id, user: store.user });
       }
     }


### PR DESCRIPTION
## Summary
- show invite notifications inside broadcast's chat feed when a host invites

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b26149745c83339913d461086176b8