### PR TITLE
Display broadcast start in main feed and square live video

### DIFF
--- a/index.html
+++ b/index.html
@@ -390,8 +390,9 @@
     .stream-composer input { flex:1; }
     #video-container {
       position: relative;
-      max-width: 640px;
-      margin: 12px auto 0;
+      width: 100%;
+      aspect-ratio: 1/1;
+      margin: 0 auto;
       border: 1px solid var(--lining);
       border-radius: 12px;
       background: var(--panel);
@@ -400,7 +401,7 @@
     #video-container video {
       width: 100%;
       height: 100%;
-      aspect-ratio: 16/9;
+      aspect-ratio: 1/1;
       object-fit: cover;
       display: block;
     }
@@ -1840,7 +1841,7 @@
           if(start && start.catch){ start.catch(() => {}); }
           broadcastVideo = mediaEl;
           sendSignal({ type: audioOnly ? 'mic-broadcaster' : 'broadcaster' });
-          if(!pendingJoinHost) postMessage({ text: '🔴 Broadcast started', broadcast: true });
+          if(!pendingJoinHost) postMessage({ text: '🔴 Broadcast started' });
         }).catch(() => { broadcasting = false; alert('Unable to access camera/microphone'); });
       }
 


### PR DESCRIPTION
## Summary
- Show "Broadcast started" message in the main post feed instead of broadcast-specific feeds
- Display live video in a square layout spanning full width for better header-to-footer coverage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b277da99988333bf4f554b5c96716e