### PR TITLE
Avoid treating broadcaster as watcher

### DIFF
--- a/index.html
+++ b/index.html
@@ -1332,7 +1332,6 @@
         streams[id] = { container: div, video: videoBox, feed, input, count, self: isSelf, started:false, vid: null, captionTrack: null, thumbEl };
         if(isSelf){
           div.classList.add('open');
-          startWatching(id);
           streams[id].started = true;
         }
       }


### PR DESCRIPTION
## Summary
- Stop invoking watcher logic for the local broadcaster so they are not registered as their own watcher.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2ebd042848333b98ca421b87fa572