### PR TITLE
Track pending host for join/mic requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -923,6 +923,8 @@
     if(joinCamBtn){
       joinCamBtn.addEventListener('click', () => {
         if(currentHost){
+          pendingJoinHost = currentHost;
+          joinCamBtn.disabled = true;
           sendSignal({ type: 'join-request', id: currentHost, user: store.user });
           systemNote('Join request sent');
         }
@@ -931,6 +933,8 @@
     if(joinMicBtn){
       joinMicBtn.addEventListener('click', () => {
         if(currentHost){
+          pendingMicHost = currentHost;
+          joinMicBtn.disabled = true;
           sendSignal({ type: 'mic-request', id: currentHost, user: store.user });
           systemNote('Mic request sent');
         }
@@ -1966,6 +1970,8 @@
       broadcastBtn.disabled = false;
       broadcastBtn.textContent = '🎥 Go Live';
       broadcastBtn.title = 'Go live';
+      if(joinCamBtn) joinCamBtn.disabled = false;
+      if(joinMicBtn) joinMicBtn.disabled = false;
         broadcastBtn.classList.remove('live');
         broadcastVideo = null;
         const share = forced ? true :
@@ -2257,6 +2263,8 @@
       pendingJoinHost = null;
       broadcastBtn.disabled = false;
       broadcastBtn.textContent = '🎥 Go Live';
+      if(joinCamBtn) joinCamBtn.disabled = false;
+      if(joinMicBtn) joinMicBtn.disabled = false;
       alert('Join request denied or busy.');
     }
 
@@ -2285,6 +2293,8 @@
       micApproved = false;
       const stream = streams[pendingMicHost];
       pendingMicHost = null;
+      if(joinMicBtn) joinMicBtn.disabled = false;
+      if(joinCamBtn) joinCamBtn.disabled = false;
       alert('Mic request denied.');
     }
 


### PR DESCRIPTION
## Summary
- capture host ID when requesting to join with camera or mic
- disable request buttons while pending and re-enable after completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2ebe46aa88333bebc9ab4196bc7dd