### PR TITLE
fix: restore join buttons on media setup failure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1878,7 +1878,13 @@
           broadcastVideo = mediaEl;
           sendSignal({ type: audioOnly ? 'mic-broadcaster' : 'broadcaster' });
           if(!pendingJoinHost) postMessage({ text: '🔴 Broadcast started' });
-        }).catch(() => { broadcasting = false; alert('Unable to access camera/microphone'); });
+        }).catch(() => {
+          broadcasting = false;
+          if(joinControls) joinControls.removeAttribute('hidden');
+          if(joinCamBtn) joinCamBtn.disabled = false;
+          if(joinMicBtn) joinMicBtn.disabled = false;
+          alert('Unable to access camera/microphone');
+        });
       }
 
       function switchCamera(){


### PR DESCRIPTION
## Summary
- Re-enable join camera/mic buttons and show join controls if media setup fails
- Prevent users from being locked out after denying camera or mic permissions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b2ed9e5f508333ba9174628ee3a7b4