### PR TITLE
Add branded icons for live feed controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -132,6 +132,10 @@
       height:100%;
       backdrop-filter: blur(8px);
     }
+    #invite-cc button img {
+      width:24px;
+      height:24px;
+    }
     #invite-cc button + button { border-left:1px solid var(--lining); }
     #profile-link { display:inline-flex; align-items:center; gap:4px; }
     #profile-link img { width:24px; height:24px; border-radius:50%; }
@@ -145,6 +149,7 @@
     #listener-count {
       cursor: default;
       pointer-events: none;
+      gap:4px;
     }
     #ghost-btn {
       background: linear-gradient(180deg, var(--accent), var(--accent-2));
@@ -658,15 +663,15 @@
           <button id="ghost-btn" class="chip" type="button" title="Hologhost" aria-label="Hologhost"><img src="static/hologhost.svg" alt="Hologhost" /></button>
           <button id="video-toggle" class="chip" type="button" title="Show live feed">Show Feed</button>
         </div>
-      <div class="status top">
-        <div class="chip" id="invite-cc">
-          <button id="stream-code-btn" type="button" title="Copy stream code">🔑 Stream Code</button>
-          <button id="camera-flip-btn" type="button" title="Switch camera">🔁 Flip</button>
-          <button id="invite-btn" type="button" title="Invite listeners">📢 Invite</button>
-          <button id="end-btn" type="button" title="End broadcast" hidden>⏹ End</button>
-          <button id="listener-count" type="button" title="Active listeners">0 listening</button>
+        <div class="status top">
+          <div class="chip" id="invite-cc">
+            <button id="stream-code-btn" type="button" title="Copy stream code" aria-label="Copy stream code"><img src="static/key.svg" alt="Stream code" /></button>
+            <button id="camera-flip-btn" type="button" title="Switch camera" aria-label="Switch camera"><img src="static/flip.svg" alt="Flip camera" /></button>
+            <button id="invite-btn" type="button" title="Invite listeners" aria-label="Invite listeners"><img src="static/invite.svg" alt="Invite" /></button>
+            <button id="end-btn" type="button" title="End broadcast" aria-label="End broadcast"><img src="static/stop.svg" alt="End" /></button>
+            <button id="listener-count" type="button" title="Active listeners" aria-label="Active listeners"><img src="static/listeners.svg" alt="Listeners" /><span id="listener-count-number">0</span></button>
+          </div>
         </div>
-      </div>
     </header>
 
       <main>
@@ -866,6 +871,7 @@
     const thumbCamera = el('#thumb-camera');
     const thumbSkip = el('#thumb-skip');
     const listenerCountBtn = el('#listener-count');
+    const listenerCountSpan = el('#listener-count-number');
     const videoContainer = el('#video-container');
     const overlayChat = el('#overlay-chat');
     const streamsEl = el('#remote-tiles');
@@ -1201,14 +1207,13 @@
       setTimeout(() => wrap.remove(), 5000);
     }
 
-    function updateHeaderButtons(){
-      const show = broadcasting;
-      [streamCodeBtn, cameraFlipBtn, swapBtn, inviteBtn, listenerCountBtn, endBtn].forEach(btn => {
-        if(btn) btn.hidden = !show;
-      });
-      document.documentElement.style.setProperty('--header-height', headerBar.offsetHeight + 'px');
-      document.documentElement.style.setProperty('--footer-height', footerBar.offsetHeight + 'px');
-    }
+      function updateHeaderButtons(){
+        [streamCodeBtn, cameraFlipBtn, swapBtn, inviteBtn, listenerCountBtn, endBtn].forEach(btn => {
+          if(btn) btn.hidden = false;
+        });
+        document.documentElement.style.setProperty('--header-height', headerBar.offsetHeight + 'px');
+        document.documentElement.style.setProperty('--footer-height', footerBar.offsetHeight + 'px');
+      }
     updateHeaderButtons();
     window.addEventListener('resize', () => {
       document.documentElement.style.setProperty('--header-height', headerBar.offsetHeight + 'px');
@@ -1404,7 +1409,7 @@
 
       function updateListenerCount(id, n){
         if(streams[id]) streams[id].count.textContent = n;
-        if(id === clientId && listenerCountBtn) listenerCountBtn.textContent = `${n} listening`;
+        if(id === clientId && listenerCountSpan) listenerCountSpan.textContent = n;
       }
     function sendJoin(){
       try { socket && socket.readyState === 1 && socket.send(JSON.stringify({ type:'join', user: store.user })); } catch {}

--- a/static/invite.svg
+++ b/static/invite.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <circle cx="8" cy="8" r="3" />
+  <path d="M2 20v-2a6 6 0 0 1 12 0v2" />
+  <line x1="19" y1="8" x2="19" y2="14" />
+  <line x1="16" y1="11" x2="22" y2="11" />
+</svg>

--- a/static/key.svg
+++ b/static/key.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <circle cx="7" cy="12" r="3" />
+  <path d="M10 12h11" />
+  <path d="M18 12v3" />
+  <path d="M15 12v3" />
+</svg>

--- a/static/listeners.svg
+++ b/static/listeners.svg
@@ -1,0 +1,10 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <circle cx="12" cy="8" r="4" />
+  <path d="M4 21v-2a8 8 0 0 1 16 0v2" />
+</svg>

--- a/static/stop.svg
+++ b/static/stop.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <rect x="5" y="5" width="14" height="14" rx="2" fill="url(#chaines)" />
+</svg>


### PR DESCRIPTION
## Summary
- Replace text labels with custom blue gradient SVG icons on live feed controls
- Always show live feed buttons by removing hidden toggling
- Add listener count badge using brand styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b2fe13ec7083339d16248854bd3c1d