### PR TITLE
Notify host when guest starts broadcasting

### DIFF
--- a/ws-server/server.js
+++ b/ws-server/server.js
@@ -523,14 +523,16 @@ wss.on("connection", (ws) => {
         }
         const hostId = guestHosts.get(ws.id);
         if(hostId){
+          const payload = JSON.stringify({ type: "guest-start", host: hostId, id: ws.id });
           const set = listeners.get(hostId);
           if(set){
-            const payload = JSON.stringify({ type: "guest-start", host: hostId, id: ws.id });
             for(const wid of set){
               const watcher = clients.get(wid);
               if(watcher && watcher.readyState === 1) watcher.send(payload);
             }
           }
+          const host = clients.get(hostId);
+          if(host && host.readyState === 1) host.send(payload);
         }
         return;
       case "mic-broadcaster":


### PR DESCRIPTION
## Summary
- Send `guest-start` event directly to the host so the UI can display host and guest feeds side by side

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b308112f248333a8c1070fcf070afe