### PR TITLE
feat: hide own live entry when hosting

### DIFF
--- a/index.html
+++ b/index.html
@@ -1222,13 +1222,19 @@
 
     function updateUsers(list){
         userCache = list;
-        liveCount.textContent = list.length;
+        const selfLive = list.some(u => typeof u !== 'string' && u.id === clientId && u.live);
+        liveCount.textContent = list.length - (selfLive ? 1 : 0);
         usersEl.innerHTML = '';
         const liveIds = new Set();
         list.forEach(u => {
-          const li = document.createElement('li');
           const name = typeof u === 'string' ? u : u.name;
           const id = typeof u === 'string' ? u : u.id;
+          if(u.live){
+            liveIds.add(id);
+            ensureStreamThumb(id, name, id === clientId);
+            if(id === clientId) return;
+          }
+          const li = document.createElement('li');
           if(u.live){
             const dot = document.createElement('span');
             dot.className = 'live-dot';
@@ -1237,8 +1243,6 @@
             camIcon.textContent = '🎥';
             camIcon.title = 'Camera';
             li.appendChild(camIcon);
-            liveIds.add(id);
-            ensureStreamThumb(id, name, id === clientId);
           }
           if(u.mic){
             li.classList.add('mic-user');


### PR DESCRIPTION
## Summary
- hide broadcaster's own live listing from user list when hosting a space
- adjust user count to account for hidden self entry

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b30da5a9b48333898a625f37f25b46