### PR TITLE
Revamp footer bar with custom SVG icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,15 +88,13 @@
       box-shadow: var(--shadow);
       border:1px solid var(--lining);
     }
-    footer .status.bottom { display:flex; width:100%; align-items:center; justify-content:space-between; gap:8px; }
-    footer .status.bottom > button { flex:0 0 100px; }
+    footer .status.bottom { display:flex; width:100%; align-items:center; justify-content:center; gap:8px; }
     footer .status.bottom .chip { display:flex; justify-content:center; }
-    footer .status.bottom .legal { flex:1 1 auto; }
-    footer .legal { font-size:12px; color:var(--muted); text-align:center; }
+    .send img { width:24px; height:24px; }
     .chip { display:inline-flex; align-items:center; gap:8px; padding:6px 10px; border:1px solid var(--lining);
             border-radius:12px; background: color-mix(in oklab, var(--panel), transparent 25%); box-shadow: var(--shadow); color: var(--fg); backdrop-filter: blur(8px); }
-    #live-chip, #theme-toggle, #cmd-list, #ghost-btn, #logout-btn, #conn-chip, #camera-btn, #swap-btn { cursor:pointer; }
-    #theme-toggle, #cmd-list, #ghost-btn, #logout-btn, #camera-btn, #swap-btn {
+    #live-chip, #theme-toggle, #cmd-list, #ghost-btn, #logout-btn, #conn-chip, #camera-btn, #swap-btn, #post-btn, #cleanup-btn, #attention-btn { cursor:pointer; }
+    #theme-toggle, #cmd-list, #ghost-btn, #logout-btn, #camera-btn, #swap-btn, #post-btn, #cleanup-btn, #attention-btn {
       width:36px;
       height:36px;
       padding:0;
@@ -104,7 +102,7 @@
       border-radius:12px;
     }
       #conn-chip img, #theme-toggle img, #ghost-btn img, #logout-btn img, #live-chip img,
-      #camera-btn img, #swap-btn img {
+      #camera-btn img, #swap-btn img, #post-btn img, #cleanup-btn img, #attention-btn img, #cmd-list img {
         width:24px;
         height:24px;
       }
@@ -527,8 +525,7 @@
       padding: 8px;
       gap: 0;
     }
-    body.broadcast-mode footer .status.bottom,
-    body.broadcast-mode footer .legal {
+    body.broadcast-mode footer .status.bottom {
       display: none;
     }
     .broadcast-controls {
@@ -700,8 +697,8 @@
         <label class="input" for="text">
           <input id="text" name="text" placeholder="Type a message… (try /wave, /me dance or /clear)" />
         </label>
-        <button class="send" id="attach" type="button" aria-label="Attach file">📎</button>
-        <button class="send" id="send" type="submit" aria-label="Send message">🐒</button>
+        <button class="send" id="attach" type="button" aria-label="Attach file"><img src="static/attach.svg" alt="Attach" /></button>
+        <button class="send" id="send" type="submit" aria-label="Send message"><img src="static/send.svg" alt="Send" /></button>
       </form>
       <input id="file" type="file" hidden />
       <div class="broadcast-controls" id="broadcast-controls" hidden>
@@ -712,14 +709,16 @@
         <label class="input" for="broadcast-text">
           <input id="broadcast-text" name="broadcast-text" placeholder="Broadcast message…" />
         </label>
-        <button class="send" id="broadcast-send" type="submit" aria-label="Send broadcast message">🐒</button>
+        <button class="send" id="broadcast-send" type="submit" aria-label="Send broadcast message"><img src="static/send.svg" alt="Send" /></button>
       </form>
       <div class="status bottom">
         <button class="chip live-btn" id="broadcast-btn" title="Go live">
-          <span class="live-dot"></span>Go Live
+          <span class="live-dot"></span><img src="static/camera.svg" alt="Go live" />Go Live
         </button>
-        <div class="legal">© <span id="year"></span> CHAINeS • Built for <a href="https://chaines.io" target="_blank" rel="noopener">chaines.io</a></div>
-        <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands">⚡</button>
+        <button id="post-btn" class="chip" title="Post" aria-label="Post"><img src="static/post.svg" alt="Post" /></button>
+        <button id="cleanup-btn" class="chip" title="Clean up" aria-label="Clean up"><img src="static/cleanup.svg" alt="Clean up" /></button>
+        <button id="attention-btn" class="chip" title="Attention" aria-label="Attention"><img src="static/attention.svg" alt="Attention" /></button>
+        <button id="cmd-list" class="chip" title="Show commands" aria-label="Show commands"><img src="static/command.svg" alt="Commands" /></button>
       </div>
     </footer>
   </div>

--- a/static/attach.svg
+++ b/static/attach.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <path d="M21.44 11.05l-9.19 9.19a5 5 0 0 1-7.07-7.07l9.19-9.19a3 3 0 1 1 4.24 4.24L10.83 16.7a1 1 0 0 1-1.41-1.41l7.07-7.07"/>
+</svg>

--- a/static/attention.svg
+++ b/static/attention.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <path d="M10.29 3.86L1.82 18a1 1 0 0 0 .86 1.5h18.64a1 1 0 0 0 .86-1.5L13.71 3.86a1 1 0 0 0-1.72 0z"/>
+  <line x1="12" y1="9" x2="12" y2="13"/>
+  <line x1="12" y1="17" x2="12" y2="17"/>
+</svg>

--- a/static/cleanup.svg
+++ b/static/cleanup.svg
@@ -1,0 +1,12 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <polyline points="3 6 5 6 21 6"/>
+  <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6m5 0V4a2 2 0 0 1 2-2h0a2 2 0 0 1 2 2v2"/>
+  <line x1="10" y1="11" x2="10" y2="17"/>
+  <line x1="14" y1="11" x2="14" y2="17"/>
+</svg>

--- a/static/command.svg
+++ b/static/command.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/>
+</svg>

--- a/static/post.svg
+++ b/static/post.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <rect x="3" y="3" width="18" height="18" rx="2"/>
+  <line x1="12" y1="8" x2="12" y2="16"/>
+  <line x1="8" y1="12" x2="16" y2="12"/>
+</svg>

--- a/static/send.svg
+++ b/static/send.svg
@@ -1,0 +1,9 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" fill="none" stroke="url(#chaines)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <defs>
+    <linearGradient id="chaines" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00C6FF" />
+      <stop offset="100%" stop-color="#0072FF" />
+    </linearGradient>
+  </defs>
+  <polygon points="3 3 21 12 3 21 7 12 3 3"/>
+</svg>


### PR DESCRIPTION
## Summary
- Replace emoji-based attach and send controls with new SVG icons
- Introduce post, cleanup, attention, and command SVG buttons and center footer layout
- Add camera icon to Go Live button and provide reusable SVG assets

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b317b9cf608333a3b1a4931efdffdc