### PR TITLE
feat: add Cardano wallet connector

### DIFF
--- a/index.html
+++ b/index.html
@@ -646,8 +646,11 @@
               <input type="checkbox" id="auto-delete" />
               Self-destruct in 5m
             </label>
-            <button class="chip" id="camera-btn" type="button" title="Turn camera off">
-              <img src="static/camera.svg" alt="Toggle camera" />
+           <button class="chip" id="camera-btn" type="button" title="Turn camera off">
+             <img src="static/camera.svg" alt="Toggle camera" />
+           </button>
+            <button class="chip" id="wallet-btn" type="button" title="Connect wallet">
+              <img src="static/wallet.svg" alt="Wallet" />
             </button>
             <button id="theme-toggle" class="chip" title="Toggle dark or light mode"><img src="static/sun.svg" alt="Toggle theme"/></button>
             <button class="chip" id="swap-btn" type="button" title="Split view" hidden>
@@ -774,6 +777,7 @@
     </div>
   </div>
 
+  <script src="static/wallet.js"></script>
   <script>
   ;(() => {
     const el = (q, parent=document) => parent.querySelector(q);

--- a/static/wallet.js
+++ b/static/wallet.js
@@ -1,0 +1,22 @@
+(function(){
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('wallet-btn');
+    if(!btn) return;
+    btn.addEventListener('click', async () => {
+      try{
+        const cardano = window.cardano;
+        if(!cardano || !cardano.nami){
+          alert('No Cardano CIP-30 wallet found.');
+          return;
+        }
+        const api = await cardano.nami.enable();
+        const addr = await api.getChangeAddress();
+        console.log('Connected to wallet:', addr);
+        alert('Wallet connected');
+      }catch(err){
+        console.error('Wallet connection failed', err);
+        alert('Wallet connection failed');
+      }
+    });
+  });
+})();

--- a/static/wallet.svg
+++ b/static/wallet.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="7" width="20" height="14" rx="2" ry="2"/>
+  <path d="M16 7V5a2 2 0 0 0-2-2H4a2 2 0 0 0-2 2v2"/>
+  <circle cx="18" cy="12" r="1"/>
+</svg>


### PR DESCRIPTION
## Summary
- add wallet button with CIP-30 Cardano wallet support
- load small script to connect to Nami wallet
- include simple wallet icon

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_68b4572e5b748333b9652a82ab4a56a0