### PR TITLE
Fix guest video placement for mobile join

### DIFF
--- a/index.html
+++ b/index.html
@@ -1968,7 +1968,7 @@
           peerConnections[msg.id] = pc;
           pc.ontrack = ev => {
             const stream = ev.streams[0];
-            if(broadcasting){
+            if(broadcasting && !joinApproved){
               if(ev.track.kind === 'video'){
                 const vid = document.createElement('video');
                 vid.srcObject = stream;


### PR DESCRIPTION
## Summary
- Keep stage handling for hosts but treat guests like viewers when handling remote tracks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_68b4af0051ec833380fd8cd9c6133169